### PR TITLE
Preparation for GPU map_reduce

### DIFF
--- a/include/mim/plug/gpu/phase/lower_map_reduce.h
+++ b/include/mim/plug/gpu/phase/lower_map_reduce.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <mim/phase.h>
+
+#include "mim/plug/gpu/gpu.h"
+
+namespace mim::plug::gpu::phase {
+
+class LowerMapReduce : public RWPhase {
+public:
+    using Super = RWPhase;
+
+    LowerMapReduce(World& world, flags_t annex)
+        : Super(world, annex) {}
+
+private:
+    const Def* rewrite_imm_App(const App*) final;
+};
+
+} // namespace mim::plug::gpu::phase

--- a/src/mim/plug/affine/affine.mim
+++ b/src/mim/plug/affine/affine.mim
@@ -76,8 +76,9 @@ axm %affine.map: {m n: Nat}
                → {sin: «n; Nat», sout: «m; Nat»}
                → ([«n; %affine.Idx»] → «m; %affine.Idx»)
                → «i: n; Idx (sin#i)»
-               → (%mem.M 0)
-               → [(%mem.M 0), «i: m; Idx (sout#i)»];
+               → {a: Nat}
+               → (%mem.M a)
+               → [(%mem.M a), «i: m; Idx (sout#i)»];
 
 ///
 /// ### %%affine.id

--- a/src/mim/plug/affine/phase/lower_index.cpp
+++ b/src/mim/plug/affine/phase/lower_index.cpp
@@ -123,8 +123,8 @@ const Def* LowerIndex::rewrite_imm_App(const App* app) {
     if (Axm::isa<affine::map>(app)) {
         // Extract f/idxs/sout from the *old* callee; we inline f's body at this call site rather than rewriting it into
         // a standalone lam, since its body may reference the threaded mem (from the divs) and would otherwise be open.
-        auto [mn, sinout, f, idxs] = app->callee()->as<App>()->uncurry_args<4>();
-        auto [sin, sout]           = sinout->projs<2>();
+        auto [mn, sinout, f, idxs, _] = app->callee()->as<App>()->uncurry_args<5>();
+        auto [sin, sout]              = sinout->projs<2>();
 
         auto _   = Restore(mem_);
         auto mem = rewrite(app->arg()); // the `%affine.map`'s mem operand

--- a/src/mim/plug/affine/phase/lower_index.cpp
+++ b/src/mim/plug/affine/phase/lower_index.cpp
@@ -126,7 +126,7 @@ const Def* LowerIndex::rewrite_imm_App(const App* app) {
         auto [mn, sinout, f, idxs, _] = app->callee()->as<App>()->uncurry_args<5>();
         auto [sin, sout]              = sinout->projs<2>();
 
-        auto _   = Restore(mem_);
+        auto __  = Restore(mem_);
         auto mem = rewrite(app->arg()); // the `%affine.map`'s mem operand
 
         auto ins    = rewrite(idxs)->projs();

--- a/src/mim/plug/btensor/phase/lower_map_reduce.cpp
+++ b/src/mim/plug/btensor/phase/lower_map_reduce.cpp
@@ -162,6 +162,7 @@ const Def* LowerMapReduce::lower_map_reduce_post(const App* app) {
         a      = w.app(a, w.tuple({sin, sout}));
         a      = w.app(a, f);
         a      = w.app(a, idxs);
+        a      = w.app(a, w.lit_nat_0());
         return w.app(a, mem)->projs<2>();
     };
 

--- a/src/mim/plug/buffer/phase/lower_ptr.cpp
+++ b/src/mim/plug/buffer/phase/lower_ptr.cpp
@@ -3,6 +3,7 @@
 #include <mim/axm.h>
 #include <mim/def.h>
 
+#include <mim/plug/gpu/gpu.h>
 #include <mim/plug/mem/mem.h>
 
 #include "mim/plug/buffer/buffer.h"
@@ -103,6 +104,17 @@ const Def* LowerPtr::rewrite_imm_App(const App* app) {
         auto [mem2, ptr] = mem::op_alloc(arr_ty_of(s, T), mem)->projs<2>();
         auto mem3        = w.call<mem::store>(Defs{mem2, ptr, pack_tuple(s, val)});
         return w.tuple({mem3, ptr});
+    } else if (auto buf_alloc_copy = Axm::isa<gpu::buf_alloc_copy>(app)) {
+        auto m0  = rewrite(buf_alloc_copy->arg(0));
+        auto m1  = rewrite(buf_alloc_copy->arg(1));
+        auto ptr = rewrite(buf_alloc_copy->arg(2));
+        return w.call(gpu::alloc_copy::block, w.tuple({m0, m1, ptr}));
+    } else if (auto buf_copy_to_host = Axm::isa<gpu::buf_copy_to_host>(app)) {
+        auto m0    = rewrite(buf_copy_to_host->arg(0));
+        auto m1    = rewrite(buf_copy_to_host->arg(1));
+        auto d_ptr = rewrite(buf_copy_to_host->arg(2));
+        auto h_ptr = rewrite(buf_copy_to_host->arg(3));
+        return w.call(gpu::copy_to_host::block, w.tuple({m0, m1, d_ptr, h_ptr}));
     }
 
     return RWPhase::rewrite_imm_App(app);

--- a/src/mim/plug/gpu/CMakeLists.txt
+++ b/src/mim/plug/gpu/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_mim_plugin(gpu
     SOURCES
         gpu.cpp
+        phase/lower_map_reduce.cpp
         phase/mem_checks.cpp
         phase/remove_double_syncs.cpp
         phase/split_apply.cpp

--- a/src/mim/plug/gpu/gpu.cpp
+++ b/src/mim/plug/gpu/gpu.cpp
@@ -7,6 +7,7 @@
 
 #include <mim/plug/mem/mem.h>
 
+#include "mim/plug/gpu/phase/lower_map_reduce.h"
 #include "mim/plug/gpu/phase/mem_checks.h"
 #include "mim/plug/gpu/phase/remove_double_syncs.h"
 #include "mim/plug/gpu/phase/split_apply.h"
@@ -61,9 +62,10 @@ void reg_phases(Flags2Phases& phases) {
     });
 
     // clang-format off
-    Phase::hook<gpu::mem_checks,          gpu::phase::MemChecks        >(phases);
-    Phase::hook<gpu::remove_double_syncs, gpu::phase::RemoveDoubleSyncs>(phases);
-    Phase::hook<gpu::split_apply,         gpu::phase::SplitApply       >(phases);
+    Phase::hook<gpu::mem_checks,                gpu::phase::MemChecks        >(phases);
+    Phase::hook<gpu::remove_double_syncs,       gpu::phase::RemoveDoubleSyncs>(phases);
+    Phase::hook<gpu::split_apply,               gpu::phase::SplitApply       >(phases);
+    Phase::hook<gpu::lower_btensor_map_reduce,  gpu::phase::LowerMapReduce   >(phases);
     // clang-format on
 }
 

--- a/src/mim/plug/gpu/gpu.mim
+++ b/src/mim/plug/gpu/gpu.mim
@@ -8,6 +8,7 @@
 ///
 plugin core;
 plugin mem;
+plugin buffer;
 import compile;
 ///
 /// ## Types
@@ -156,6 +157,24 @@ let %gpu.alloc_copy.block = lm {T: *}
     let (m0, m1) = %gpu.copy_to_device.block (m0, m1, ptr, d_ptr);
     (m0, m1, d_ptr);
 ///
+/// ### Buffer Operations
+///
+/// #### %%gpu.buf_alloc_copy
+///
+/// Placeholder for copying a host-side `%buffer.Buf` to the device.
+/// Unlike `%gpu.alloc_copy(block)`, this operates directly on the still-abstract `%buffer.Buf`
+axm %gpu.buf_alloc_copy: {r: Nat, s: «r; Nat», T: *}
+                       → [%mem.M 0, %gpu.GlobalM, %buffer.Buf (r, s, T)]
+                       → [%mem.M 0, %gpu.GlobalM, %gpu.GlobalPtr «s; T»];
+///
+/// #### %%gpu.buf_copy_to_host
+///
+/// Placeholder for copying device data to a host-side `%buffer.Buf`.
+/// Unlike `%gpu.copy_to_host(block)`, this operates directly on the still-abstract `%buffer.Buf`
+axm %gpu.buf_copy_to_host: {r: Nat, s: «r; Nat», T: *}
+                       → [%mem.M 0, %gpu.GlobalM, %gpu.GlobalPtr «s; T», %buffer.Buf (r, s, T)]
+                       → [%mem.M 0, %gpu.GlobalM];
+///
 /// ### Async Memory Operations
 ///
 /// #### %%gpu.alloc(asyn)
@@ -234,6 +253,7 @@ axm %gpu.host_malloc2gpualloc_repl: %compile.Phase;
 axm %gpu.mem_checks:                %compile.Phase;
 axm %gpu.remove_double_syncs:       %compile.Phase;
 axm %gpu.split_apply:               %compile.Phase;
+axm %gpu.lower_btensor_map_reduce:  %compile.Phase;
 ///
 /// ### Pipelines
 ///

--- a/src/mim/plug/gpu/phase/lower_map_reduce.cpp
+++ b/src/mim/plug/gpu/phase/lower_map_reduce.cpp
@@ -1,0 +1,7 @@
+#include "mim/plug/gpu/phase/lower_map_reduce.h"
+
+namespace mim::plug::gpu::phase {
+
+const Def* LowerMapReduce::rewrite_imm_App(const App* app) { return Super::rewrite_imm_App(app); }
+
+} // namespace mim::plug::gpu::phase

--- a/src/mim/plug/gpu/phase/split_apply.cpp
+++ b/src/mim/plug/gpu/phase/split_apply.cpp
@@ -1,4 +1,3 @@
-
 #include "mim/plug/gpu/phase/split_apply.h"
 
 #include <mim/driver.h>

--- a/src/mim/plug/opt/opt.mim
+++ b/src/mim/plug/opt/opt.mim
@@ -45,6 +45,7 @@ lam extern _default_compile (): %compile.Phase =
         %compile.cond "tensor" (%compile.named "%mem.add_mem"),
 
         // btensor
+        %compile.named "%gpu.lower_btensor_map_reduce",
         %compile.named "%btensor.lower_map_reduce",
         %compile.unload "btensor",
 

--- a/src/mim/plug/tensor/phase/lower_map_reduce.cpp
+++ b/src/mim/plug/tensor/phase/lower_map_reduce.cpp
@@ -185,6 +185,7 @@ const Def* LowerMapReduce::lower_map_reduce(const App* app) {
         a      = w.app(a, w.tuple({sin, sout}));
         a      = w.app(a, f);
         a      = w.app(a, idxs);
+        a      = w.app(a, w.lit_nat_0());
         return w.app(a, w.bot(mem0))->proj(2, 1); // drop the returned mem at proj 0
     };
 


### PR DESCRIPTION
This PR implements fixes and the framework for a phase that lowers btensor map-reduce calls to GPU operations and GPU kernel launches that compute the map-reduce operation.
This PR *does not* implement this phase yet.