### PR TITLE
Add symbolic contraction support in dot product and enhance normalization logic

### DIFF
--- a/lit/tensor/dot_symbolic_div.mim
+++ b/lit/tensor/dot_symbolic_div.mim
@@ -1,0 +1,40 @@
+// RUN: %mim %s -p opt -o - | %FileCheck %s
+
+// A matrix product whose contraction extent is SYMBOLIC but built in factored form: ceil(n/4)*4,
+// the shape a padded row gets from %tensor.pad. dot_schedule's tile-size guard asks whether the
+// extent is *divisible* by 4, not whether it is a literal, and %core.nat's `(c*x)/c` cancellation
+// discharges that under a symbolic `n`. So the contraction is register-blocked by 4 exactly as it
+// would be for a literal extent, and the outer contraction loop runs the symbolic (n+3)/4 times.
+// Contrast dot_dynamic.mim, where an opaque `k` leaves the guard undecided and takes ts = 1.
+
+plugin core;
+plugin tensor;
+plugin affine;
+plugin mem;
+
+lam nat_ring (): %tensor.Ring = (Nat, 0, %core.nat.add, %core.nat.mul);
+
+// CHECK-DAG: fun extern mm_pad
+fun extern mm_pad {m n l: Nat} (
+        a: «m, %core.nat.mul (%core.nat.div (%core.nat.add (n, 3), 4), 4); Nat»,
+        b: «%core.nat.mul (%core.nat.div (%core.nat.add (n, 3), 4), 4), l; Nat»): «m, l; Nat» =
+    return (%tensor.product_2d_impl 1 (nat_ring ()) (a, b));
+
+lam extern _compile (): %compile.Phase =
+    %compile.phases ff (
+        %compile.cleanup,
+        %tensor.lower_tensor,
+        %tensor.lower_map_reduce,
+        %compile.cleanup,
+    );
+
+// The extent stays symbolic and factored: the strip-mined outer count is (3 + n) / 4.
+// CHECK-DAG: %core.nat.add (3, [[N:[_a-zA-Z0-9]+]])
+// CHECK-DAG: %core.nat.div ([[A:[_a-zA-Z0-9]+]], 4)
+
+// The split reduction dim recombines as `i * 4 + j`, i.e. the tile size really is 4 and not the
+// neutral 1 -- this is the line that regresses if the guard goes back to requiring a literal.
+// CHECK-DAG: %affine.semiop.mul ([[I:[_a-zA-Z0-9]+]], 4)
+
+// The guard must not survive to the output: it is decided here, not residualized.
+// CHECK-NOT: if_static

--- a/src/mim/plug/core/normalizers.cpp
+++ b/src/mim/plug/core/normalizers.cpp
@@ -531,6 +531,18 @@ const Def* normalize_nat(const Def* type, const Def* callee, const Def* arg) {
         }
     }
 
+    // (c * x) / b = (c / b) * x and (c * x) % b = 0 if c % b == 0
+    if (lb && *lb != 0 && (id == nat::div || id == nat::mod)) {
+        if (auto m = Axm::isa(nat::mul, a)) {
+            const Def* marg = m->arg();
+            auto [c, x]     = marg->projs<2>();
+            if (auto lc = Lit::isa(c); lc && *lc != 0 && *lc % *lb == 0) {
+                if (id == nat::mod) return world.lit_nat_0();
+                return world.call(nat::mul, Defs{world.lit_nat(*lc / *lb), x});
+            }
+        }
+    }
+
     if (a == b) {
         switch (id) {
             case nat::add: return world.call(nat::mul, Defs{world.lit_nat(2), a}); // a + a = 2 * a

--- a/src/mim/plug/tensor/tensor.mim
+++ b/src/mim/plug/tensor/tensor.mim
@@ -472,14 +472,19 @@ lam conv_schedule (stride dilation: «2; Nat») (t: Tileable): Tileable =
 /// The dot-product schedule for a contraction whose right operand stores the last output dim
 /// unit-stride (A·B): that dim is invariant in the left operand, so it runs innermost over a row
 /// of accumulators (GEMM-style vectorization). The innermost contraction is register-blocked —
-/// strip-mined by 4 and the tile unrolled — when its extent is compile-time known and divisible;
-/// an extent still open at lowering time (a runtime shape) takes the neutral tile (`ts = 1`) via
-/// %%tensor.if_static, so one selector serves static and dynamic shapes.
+/// strip-mined by 4 and the tile unrolled — whenever its DIVISIBILITY is decided, which is weaker
+/// than the extent being a literal: an extent built in factored form (`«(n+3)/4*4, …»`, say a
+/// padded row) folds the guard to `tt` under a symbolic `n`, because %%core.nat cancels `(c*x)/c`.
+/// %%tensor.if_static therefore gates on the tile size itself rather than on `K`: a tile that has
+/// folded to a literal is a decided tile, whether it was decided from a literal extent or from a
+/// symbolic one. An undecided divisibility is still open at lowering time and takes the neutral
+/// tile (`ts = 1`), so one selector serves static, symbolic and runtime shapes.
 lam dot_schedule (r_out: Nat) (t: Tileable): Tileable =
-    let r  = %core.nat.add (t#Ro, t#Rr);
-    let d  = %core.nat.sub (r, 1);
-    let K  = t#Sr#(%core.idx r 0 d);
-    let ts = %tensor.if_static (K, (1, 4)#(%core.ncmp.e (%core.nat.mul (%core.nat.div (K, 4), 4), K)), 1);
+    let r   = %core.nat.add (t#Ro, t#Rr);
+    let d   = %core.nat.sub (r, 1);
+    let K   = t#Sr#(%core.idx r 0 d);
+    let ts0 = (1, 4)#(%core.ncmp.e (%core.nat.mul (%core.nat.div (K, 4), 4), K));
+    let ts  = %tensor.if_static (ts0, ts0, 1);
     unroll_trailing (%tensor.strip_mine_red (vectorize (t, %core.nat.sub (r_out, 1)), d, ts), 1);
 
 /// The dot-product schedule for a contraction whose right operand stores the CONTRACTION


### PR DESCRIPTION
This allows us to actually make the point that we just need to symbolically need to know that n is divisible by n, instead of requiring n to be fully known.