### PR TITLE
Feature/ops

### DIFF
--- a/lit/ackermann.mim
+++ b/lit/ackermann.mim
@@ -8,22 +8,24 @@ plugin core;
 plugin compile;
 plugin mem;
 
+use core.ops.n;
+
 // Only 2 of the 3 recursive calls forward `k`, so `compile.static_arg_opt` seeds the split with `k`,
 // drops it from the loop, and routes the remaining call through the wrapper.
 con ack (m n: Nat, k: Cn Nat) =
-    (m_ne_0, m_eq_0)#(core.ncmp.e (m, 0)) ()
+    (m_ne_0, m_eq_0)#(m == 0) ()
     where
-        con m_eq_0() = k (core.nat.add (n, 1));
+        con m_eq_0() = k (n + 1);
 
         con m_ne_0() =
-            (n_ne_0, n_eq_0)#(core.ncmp.e (n, 0)) ()
+            (n_ne_0, n_eq_0)#(n == 0) ()
             where
-                con n_eq_0() = ack (core.nat.sub (m, 1), 1, k);
+                con n_eq_0() = ack (m - 1, 1, k);
 
                 con n_ne_0() =
-                    ack (m, core.nat.sub (n, 1), inner)
+                    ack (m, n - 1, inner)
                     where
-                        con inner (v: Nat) = ack (core.nat.sub (m, 1), v, k);
+                        con inner (v: Nat) = ack (m - 1, v, k);
                     end;
             end;
     end;

--- a/lit/affine/affine_index.mim
+++ b/lit/affine/affine_index.mim
@@ -8,6 +8,8 @@ plugin core;
 plugin affine;
 plugin mem;
 
+use core.ops.u.w;
+
 // f exercises the affine index algebra over two input indices `a`, `b`:
 //   out0 = (a + b) - b = a   (op.add + op.sub)
 //   out1 = a * 3             (semiop.mul)
@@ -20,9 +22,7 @@ extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I32, 0), 0), ret
     let b = 4I32;
     let (m, (r1, r2, r3)) = affine.map f (a, b) m;
     // sum = a + 3*a + 5 = 4*a + 5
-    let s0 = core.wrap.add 0 (r1, r2);
-    let s  = core.wrap.add 0 (s0, r3);
-    return (m, s);
+    return (m, r1 + r2 + r3);
 
 // The whole affine index algebra must be gone after affine.lower_index.
 // CHECK-NOT: affine.Index

--- a/lit/affine/affine_index_op_mul.mim
+++ b/lit/affine/affine_index_op_mul.mim
@@ -8,6 +8,8 @@ plugin core;
 plugin affine;
 plugin mem;
 
+use core.ops.u.w;
+
 // f exercises the affine index algebra over two input indices `a`, `b`:
 //   out0 = (a + b) - b = a   (op.add + op.sub)
 //   out1 = a * 3             (op.mul)
@@ -20,9 +22,7 @@ extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I32, 0), 0), ret
     let b = 4I32;
     let (m, r) = affine.map f (a, b) m;
     // sum = a + 3*a + 5 = 4*a + 5
-    let s0 = core.wrap.add 0 (r#0₃, r#1₃);
-    let s  = core.wrap.add 0 (s0, r#2₃);
-    return (m, s);
+    return (m, r#0₃ + r#1₃ + r#2₃);
 
 // The whole affine index algebra must be gone after affine.lower_index.
 // CHECK-NOT: affine.Index

--- a/lit/affine/dynamic_for.mim
+++ b/lit/affine/dynamic_for.mim
@@ -8,12 +8,14 @@ plugin core;
 plugin affine;
 plugin mem;
 
+use core.ops.u.w;
+
 extern con atoi [mem.M 0, mem.Ptr («⊤:Nat; I8», 0), Cn [mem.M 0, I32]];
 
 extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr («⊤:Nat; mem.Ptr («⊤:Nat; I8», 0)», 0), return: Cn [mem.M 0, I32]) =
     con for_body (i: I32, (acc_a acc_b: I32), continue: Cn [I32, I32]) =
-        let a: I32 = core.wrap.add 0 (i, acc_a);
-        let b: I32 = core.wrap.sub 0 (i, acc_b);
+        let a: I32 = i + acc_a;
+        let b: I32 = i - acc_b;
         continue (a, b);
 
     con atoi_cont_begin (m: mem.M 0, start: I32) =

--- a/lit/affine/for_2acc.mim
+++ b/lit/affine/for_2acc.mim
@@ -8,12 +8,14 @@ plugin core;
 plugin affine;
 plugin mem;
 
+use core.ops.u.w;
+
 extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I32, 0), 0), return: Cn [mem.M 0, I32]) =
     affine.For for_body for_exit (0I32, argc, 1I32, (0I32, 0I32))
     where
         con for_body (i: I32, acc: [I32, I32], continue: Cn [[I32, I32]]) =
-            let a: I32 = core.wrap.add 0 (i, acc#ff);
-            let b: I32 = core.wrap.sub 0 (i, acc#tt);
+            let a: I32 = i + acc#ff;
+            let b: I32 = i - acc#tt;
             continue (a, b);
         con for_exit (acc: [I32, I32]) = return (m, acc#ff);
     end;

--- a/lit/affine/for_2acc_2types.mim
+++ b/lit/affine/for_2acc_2types.mim
@@ -8,12 +8,14 @@ plugin core;
 plugin affine;
 plugin mem;
 
+use core.ops.u.w;
+
 extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I32, 0), 0), return: Cn [mem.M 0, Idx 0]) =
     affine.For for_body for_exit (0I32, argc, 1I32, (0I32, 0:(Idx 0)))
     where
         con for_body (i: I32, acc: [I32, Idx 0], continue: Cn [[I32, Idx 0]]) =
-            let a: I32 = core.wrap.add 0 (i, acc#ff);
-            let b: Idx 0 = core.wrap.add 0 (core.conv.u 0 i, acc#tt);
+            let a: I32 = i + acc#ff;
+            let b: Idx 0 = core.conv.u 0 i + acc#tt;
             continue (a, b);
         con for_exit (acc: [I32, Idx 0]) = return (m, acc#tt);
     end;

--- a/lit/affine/for_2acc_real.mim
+++ b/lit/affine/for_2acc_real.mim
@@ -9,13 +9,13 @@ plugin math;
 plugin affine;
 plugin mem;
 
+use core.ops.u.w;
+
 extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I32, 0), 0), return: Cn [mem.M 0, Idx 0]) =
     affine.For for_body for_exit (0I32, argc, 1I32, (0I32, 0:math.F64))
     where
         con for_body (i: I32, (acc_a: I32, acc_b: math.F64), continue: Cn [[I32, math.F64]]) =
-            let a = core.wrap.add 0 (i, acc_a);
-            let b = math.conv.u2f math.f64 (core.wrap.add 0 (core.conv.u 0 i, math.conv.f2u 0 acc_b));
-            continue (a, b);
+            continue (i + acc_a, math.conv.u2f math.f64 (core.conv.u 0 i + math.conv.f2u 0 acc_b));
         con for_exit (acc: [I32, math.F64]) = return (m, math.conv.f2u 0 acc#tt);
     end;
 

--- a/lit/affine/for_over_mem.mim
+++ b/lit/affine/for_over_mem.mim
@@ -8,6 +8,8 @@ plugin core;
 plugin affine;
 plugin mem;
 
+use core.ops.u.w;
+
 let arr_size = ⊤:Nat;
 // let arr_size = 16;
 
@@ -16,16 +18,15 @@ extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I32, 0), 0), ret
     affine.For for_body for_exit (0I32, argc, 1I32, (m, 0I32, 0I32))
     where
         con for_body (i: I32, (m: mem.M 0, acc_a acc_b: I32), continue: Cn [mem.M 0, I32, I32]) =
-            let a   = core.wrap.add 0 (i, acc_a);
-            let b   = core.wrap.sub 0 (i, acc_b);
+            let a   = i + acc_a;
+            let b   = i - acc_b;
             let lea = mem.lea (ptr, core.conv.u arr_size i);
             let m = mem.store (m, lea, a);
             continue (m, a, b);
 
         con for_exit (m: mem.M 0, _: I32, _: I32) =
-            let lea = mem.lea (ptr, core.conv.u arr_size (core.wrap.sub 0 (argc, 4I32)));
-            let ld  = mem.load (m, lea);
-            return ld;
+            let lea = mem.lea (ptr, core.conv.u arr_size (argc - 4I32));
+            return (mem.load (m, lea));
     end;
 
 

--- a/lit/affine/for_vec_hint.mim
+++ b/lit/affine/for_vec_hint.mim
@@ -15,14 +15,16 @@ plugin affine;
 plugin ll;
 plugin mem;
 
+use core.ops.u.w;
+
 extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I32, 0), 0), return: Cn [mem.M 0, I32]) =
     affine.For (ll.vec vec_body) vec_exit (0I32, 8I32, 1I32, 0I32)
     where
-        con vec_body (i acc: I32, continue: Cn I32) = continue (core.wrap.add 0 (acc, argc));
+        con vec_body (i acc: I32, continue: Cn I32) = continue (acc + argc);
         con vec_exit (acc: I32) =
             affine.For plain_body plain_exit (0I32, 64I32, 1I32, acc)
             where
-                con plain_body (i acc: I32, continue: Cn I32) = continue (core.wrap.add 0 (acc, 1I32));
+                con plain_body (i acc: I32, continue: Cn I32) = continue (acc + 1I32);
                 con plain_exit (acc: I32) = return (m, acc);
             end;
     end;

--- a/lit/autodiff/autodiff_mult_in_call.mim
+++ b/lit/autodiff/autodiff_mult_in_call.mim
@@ -5,6 +5,8 @@ plugin core;
 plugin autodiff;
 plugin mem;
 
+use core.ops.u.w;
+
 
 con swap ((a b: I32), return: Cn [I32, I32]) = return (b, a);
 
@@ -21,12 +23,7 @@ extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), retu
             pb(1I32, pb_ret_cont)
             where
                 con pb_ret_cont (pr_a pr_b: I32) =
-                    let sr = core.wrap.mul 0 (10000I32, r);
-                    let sa = core.wrap.mul 0 (100I32, pr_a);
-                    let sb = pr_b;
-                    let sp = core.wrap.add 0 (sa, sb);
-                    let o  = core.wrap.add 0 (sr, sp);
-                    return (m, o);
+                    return (m, 10000I32 * r + (100I32 * pr_a + pr_b));
             end;
     end;
 

--- a/lit/autodiff/autodiff_mult_in_call2.mim
+++ b/lit/autodiff/autodiff_mult_in_call2.mim
@@ -5,6 +5,8 @@ plugin core;
 plugin autodiff;
 plugin mem;
 
+use core.ops.u.w;
+
 
 con snd ((a b: I32), return: Cn I32) = return (b);
 con f ((a b: I32), return: Cn I32) = snd ((a, b), return);
@@ -18,11 +20,11 @@ extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), retu
             pb(1I32, pb_ret_cont)
             where
                 con pb_ret_cont (pr_a pr_b: I32) =
-                    let sr = core.wrap.mul 0 (10000I32, r);
-                    let sa = core.wrap.mul 0 (100I32, pr_a);
+                    let sr = 10000I32 * r;
+                    let sa = 100I32 * pr_a;
                     let sb = pr_b;
-                    let sp = core.wrap.add 0 (sa, sb);
-                    let o  = core.wrap.add 0 (sr, sp);
+                    let sp = sa + sb;
+                    let o  = sr + sp;
                     return (m, o)
             end;
     end;

--- a/lit/autodiff/autodiff_mult_in_call2_2.mim
+++ b/lit/autodiff/autodiff_mult_in_call2_2.mim
@@ -5,6 +5,8 @@ plugin autodiff;
 plugin core;
 plugin mem;
 
+use core.ops.u.w;
+
 fun fst(a b: I32): I32 = return a;
 fun f(a b: I32): I32 = fst ((a, b), return);
 
@@ -17,12 +19,7 @@ extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), retu
             pb(1I32, pb_ret_cont)
             where
                 con pb_ret_cont (pr_a pr_b: I32) =
-                    let sr = core.wrap.mul 0 (10000I32, r);
-                    let sa = core.wrap.mul 0 (100I32, pr_a);
-                    let sb = pr_b;
-                    let sp = core.wrap.add 0 (sa, sb);
-                    let o  = core.wrap.add 0 (sr, sp);
-                    return (m, o);
+                    return (m, 10000I32 * r + (100I32 * pr_a + pr_b));
             end;
     end;
 

--- a/lit/autodiff/autodiff_mult_in_call2_3.mim
+++ b/lit/autodiff/autodiff_mult_in_call2_3.mim
@@ -5,6 +5,8 @@ plugin core;
 plugin autodiff;
 plugin mem;
 
+use core.ops.u.w;
+
 
 con snd ((a b: I32), return: Cn I32) = return (b);
 con f ((a b: I32), return: Cn I32) = snd( (b, a) , return);
@@ -18,12 +20,7 @@ extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), retu
             pb(1I32, pb_ret_cont)
             where
                 con pb_ret_cont (pr_a pr_b: I32) =
-                    let sr = core.wrap.mul 0 (10000I32, r);
-                    let sa = core.wrap.mul 0 (100I32, pr_a);
-                    let sb = pr_b;
-                    let sp = core.wrap.add 0 (sa, sb);
-                    let o  = core.wrap.add 0 (sr, sp);
-                    return (m, o);
+                    return (m, 10000I32 * r + (100I32 * pr_a + pr_b));
             end;
     end;
 

--- a/lit/autodiff/autodiff_mult_in_call_cont.mim
+++ b/lit/autodiff/autodiff_mult_in_call_cont.mim
@@ -5,6 +5,8 @@ plugin core;
 plugin autodiff;
 plugin mem;
 
+use core.ops.u.w;
+
 
 con f ((a b: I32), return: Cn I32) =
     f_cont((b, a))
@@ -21,12 +23,7 @@ extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), retu
             pb(1I32, pb_ret_cont)
             where
                 con pb_ret_cont (pr_a pr_b: I32) =
-                    let sr = core.wrap.mul 0 (10000I32, r);
-                    let sa = core.wrap.mul 0 (100I32, pr_a);
-                    let sb = pr_b;
-                    let sp = core.wrap.add 0 (sa, sb);
-                    let o  = core.wrap.add 0 (sr, sp);
-                    return (m, o);
+                    return (m, 10000I32 * r + (100I32 * pr_a + pr_b));
             end;
     end;
 

--- a/lit/autodiff/call_autodiff.mim
+++ b/lit/autodiff/call_autodiff.mim
@@ -9,8 +9,7 @@ use core.ops.u.w;
 
 
 fun g(b: I32): I32 =
-    let c = 3I32 * b;
-    return c;
+    return (3I32 * b);
 
 fun f(a: I32): I32 =
     let b = 2I32 * a;

--- a/lit/autodiff/call_autodiff.mim
+++ b/lit/autodiff/call_autodiff.mim
@@ -5,13 +5,15 @@ plugin core;
 plugin autodiff;
 plugin mem;
 
+use core.ops.u.w;
+
 
 fun g(b: I32): I32 =
-    let c = core.wrap.mul 0 (3I32, b);
+    let c = 3I32 * b;
     return c;
 
 fun f(a: I32): I32 =
-    let b = core.wrap.mul 0 (2I32, a);
+    let b = 2I32 * a;
     g (b, return);
 
 extern con main(m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), return: Cn [mem.M 0, I32]) =
@@ -24,9 +26,7 @@ extern con main(m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), retur
             pb(1I32, pb_ret_cont)
             where
                 con pb_ret_cont (pr: I32) =
-                    let c = core.wrap.mul 0 (100I32, r);
-                    let d = core.wrap.add 0 (c, pr);
-                    return (m, d);
+                    return (m, 100I32 * r + pr);
             end;
     end;
 

--- a/lit/autodiff/call_autodiff_cont.mim
+++ b/lit/autodiff/call_autodiff_cont.mim
@@ -9,15 +9,13 @@ use core.ops.u.w;
 
 
 fun g(b: I32): I32 =
-    let c = 3I32 + b;
-    return c;
+    return (3I32 + b);
 
 // 4(3+2a)
 fun f(a: I32): I32 =
     let b = 2I32 * a;
     ret x = g $ b;
-    let c = 4I32 * x;
-    return c;
+    return (4I32 * x);
 
 extern con main(m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), return: Cn [mem.M 0, I32]) =
     let f_diff = autodiff.ad f;

--- a/lit/autodiff/call_autodiff_cont.mim
+++ b/lit/autodiff/call_autodiff_cont.mim
@@ -5,16 +5,18 @@ plugin core;
 plugin autodiff;
 plugin mem;
 
+use core.ops.u.w;
+
 
 fun g(b: I32): I32 =
-    let c = core.wrap.add 0 (3I32, b);
+    let c = 3I32 + b;
     return c;
 
 // 4(3+2a)
 fun f(a: I32): I32 =
-    let b = core.wrap.mul 0 (2I32, a);
+    let b = 2I32 * a;
     ret x = g $ b;
-    let c = core.wrap.mul 0 (4I32, x);
+    let c = 4I32 * x;
     return c;
 
 extern con main(m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), return: Cn [mem.M 0, I32]) =
@@ -26,9 +28,7 @@ extern con main(m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), retur
             pb(1I32, pb_ret_cont)
             where
                 con pb_ret_cont (pr: I32) =
-                    let c = core.wrap.mul 0 (100I32, r);
-                    let d = core.wrap.add 0 (c, pr);
-                    return (m, d);
+                    return (m, 100I32 * r + pr);
             end;
     end;
 

--- a/lit/autodiff/general/2out.mim
+++ b/lit/autodiff/general/2out.mim
@@ -5,17 +5,17 @@ plugin core;
 plugin autodiff;
 plugin mem;
 
+use core.ops.u.w;
+
 con f (a: I32, return: Cn [I32, I32]) =
-    let b = core.wrap.mul 0 (2I32, a);
-    let c = core.wrap.mul 0 (3I32, a);
+    let b = 2I32 * a;
+    let c = 3I32 * a;
     return (b, c);
 
 extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), return: Cn [mem.M 0, I32]) =
     con ret_cont ((r1 r2: I32)) =
         con pb_ret_cont (pr: I32) =
-            let c = core.wrap.mul 0 (100I32, r1);
-            let d = core.wrap.add 0 (c, pr);
-            return (m, d);
+            return (m, 100I32 * r1 + pr);
         // pb((1I32,0I32,pb_ret_cont)
         pb_ret_cont 1I32;
 

--- a/lit/autodiff/general/invoke_ds.mim
+++ b/lit/autodiff/general/invoke_ds.mim
@@ -6,6 +6,8 @@ plugin cps;
 plugin autodiff;
 plugin mem;
 
+use core.ops.u.w;
+
 con extract_pb1 (s: mem.M 0, ret_cont: Cn [mem.M 0, «2; I32»]) =
     con k arg: [mem.M 0, «2; I32»] = ret_cont arg;
     k (s, ‹2; 0I32›);
@@ -19,9 +21,9 @@ extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr ((I8), 0), 0), re
     let b: [mem.M 0, «2; I32»] = cps.cps2ds extract_pb2 1I32;
     let m: mem.M 0 = autodiff.add (a#ff, b#0₂);
     let t: «2; I32» = autodiff.add (a#tt, b#1₂);
-    let x: I32 = core.wrap.mul 0 (100I32, t#0₂);
-    let y: I32 = core.wrap.add 0 (t#1₂, x);
-    let z: I32 = core.wrap.add 0 (430000I32, y);
+    let x: I32 = 100I32 * t#0₂;
+    let y: I32 = t#1₂ + x;
+    let z: I32 = 430000I32 + y;
     return (m, z);
 
 // CHECK-DAG: return{{.*}}430001

--- a/lit/autodiff/id_autodiff_info_out.mim
+++ b/lit/autodiff/id_autodiff_info_out.mim
@@ -5,10 +5,11 @@ plugin core;
 plugin autodiff;
 plugin mem;
 
+use core.ops.u.w;
+
 
 fun f(a: I32): I32 =
-    let b = a;
-    return b;
+    return a;
 
 extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), return: Cn [mem.M 0, I32]) =
     let f_diff = autodiff.ad f;
@@ -21,9 +22,7 @@ extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), retu
             pb(1I32, pb_ret_cont)
             where
                 con pb_ret_cont (pr: I32) =
-                    let c = core.wrap.mul 0 (100I32, r);
-                    let d = core.wrap.add 0 (c, pr);
-                    return (m, d);
+                    return (m, 100I32 * r + pr);
             end;
     end;
 

--- a/lit/autodiff/id_autodiff_mult_in.mim
+++ b/lit/autodiff/id_autodiff_mult_in.mim
@@ -5,9 +5,10 @@ plugin core;
 plugin autodiff;
 plugin mem;
 
+use core.ops.u.w;
+
 fun f(a b: I32): I32 =
-    let x = b;
-    return x;
+    return b;
 
 extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), return: Cn [mem.M 0, I32]) =
     let f_diff = autodiff.ad f;
@@ -18,11 +19,11 @@ extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), retu
             pb(1I32, pb_ret_cont)
             where
                 con pb_ret_cont (pr_a pr_b: I32) =
-                    let sr = core.wrap.mul 0 (10000I32, r);
-                    let sa = core.wrap.mul 0 (100I32, pr_a);
+                    let sr = 10000I32 * r;
+                    let sa = 100I32 * pr_a;
                     let sb = pr_b;
-                    let sp = core.wrap.add 0 (sa, sb);
-                    let o  = core.wrap.add 0 (sr, sp);
+                    let sp = sa + sb;
+                    let o  = sr + sp;
                     return (m, o)
             end;
     end;

--- a/lit/autodiff/id_autodiff_mult_in_mem.mim
+++ b/lit/autodiff/id_autodiff_mult_in_mem.mim
@@ -5,10 +5,11 @@ plugin core;
 plugin autodiff;
 plugin mem;
 
+use core.ops.u.w;
+
 
 fun f(m: mem.M 0, (a b: I32)): [mem.M 0, I32] =
-    let x = b;
-    return (m, x);
+    return (m, b);
 
 extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), return: Cn [mem.M 0, I32]) =
     let f_diff = autodiff.ad f;
@@ -19,12 +20,7 @@ extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), retu
             pb ((rmem, 1I32), pb_ret_cont)
             where
                 con pb_ret_cont (pb_mem: mem.M 0, (pr_a pr_b: I32)) =
-                    let sr = core.wrap.mul 0 (10000I32, r);
-                    let sa = core.wrap.mul 0 (100I32, pr_a);
-                    let sb = pr_b;
-                    let sp = core.wrap.add 0 (sa, sb);
-                    let o  = core.wrap.add 0 (sr, sp);
-                    return (pb_mem, o);
+                    return (pb_mem, 10000I32 * r + (100I32 * pr_a + pr_b));
             end;
     end;
 

--- a/lit/autodiff/id_autodiff_mult_in_mult.mim
+++ b/lit/autodiff/id_autodiff_mult_in_mult.mim
@@ -5,10 +5,11 @@ plugin core;
 plugin autodiff;
 plugin mem;
 
+use core.ops.u.w;
+
 
 fun f(a b: I32): I32 =
-    let x = core.wrap.mul 0 (b, a);
-    return x;
+    return (b * a);
 
 extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), return: Cn [mem.M 0, I32]) =
     let f_diff = autodiff.ad f;
@@ -19,12 +20,7 @@ extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), retu
             pb(1I32, pb_ret_cont)
             where
                 con pb_ret_cont (pr_a pr_b: I32) =
-                    let sr = core.wrap.mul 0 (10000I32, r);
-                    let sa = core.wrap.mul 0 (100I32, pr_a);
-                    let sb = pr_b;
-                    let sp = core.wrap.add 0 (sa, sb);
-                    let o  = core.wrap.add 0 (sr, sp);
-                    return (m, o);
+                    return (m, 10000I32 * r + (100I32 * pr_a + pr_b));
             end;
     end;
 

--- a/lit/autodiff/id_autodiff_mult_in_mult2.mim
+++ b/lit/autodiff/id_autodiff_mult_in_mult2.mim
@@ -5,9 +5,10 @@ plugin core;
 plugin autodiff;
 plugin mem;
 
+use core.ops.u.w;
+
 fun f(a b: I32): I32 =
-    let x = core.wrap.mul 0 (a, b);
-    return x;
+    return (a * b);
 
 extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), return: Cn [mem.M 0, I32]) =
     let f_diff = autodiff.ad f;
@@ -18,12 +19,7 @@ extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), retu
             pb(1I32, pb_ret_cont)
             where
                 con pb_ret_cont (pr_a pr_b: I32) =
-                    let sr = core.wrap.mul 0 (10000I32, r);
-                    let sa = core.wrap.mul 0 (100I32, pr_a);
-                    let sb = pr_b;
-                    let sp = core.wrap.add 0 (sa, sb);
-                    let o  = core.wrap.add 0 (sr, sp);
-                    return (m, o);
+                    return (m, 10000I32 * r + (100I32 * pr_a + pr_b));
             end;
     end;
 

--- a/lit/autodiff/multiply2_autodiff.mim
+++ b/lit/autodiff/multiply2_autodiff.mim
@@ -5,9 +5,11 @@ plugin core;
 plugin autodiff;
 plugin mem;
 
+use core.ops.u.w;
+
 fun f(a: I32): I32 =
-    let b = core.wrap.add 0 (3I32, a);
-    let c = core.wrap.mul 0 (a, b);
+    let b = 3I32 + a;
+    let c = a * b;
     // (3+a)a => 3 + 2a
     return c;
 
@@ -21,9 +23,7 @@ extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), retu
             pb(1I32, pb_ret_cont)
             where
                 con pb_ret_cont (pr: I32) =
-                    let c = core.wrap.mul 0 (100I32, r);
-                    let d = core.wrap.add 0 (c, pr);
-                    return (m, d);
+                    return (m, 100I32 * r + pr);
             end;
     end;
 

--- a/lit/autodiff/multiply_autodiff.mim
+++ b/lit/autodiff/multiply_autodiff.mim
@@ -5,10 +5,11 @@ plugin core;
 plugin autodiff;
 plugin mem;
 
+use core.ops.u.w;
+
 
 fun f(a: I32): I32 =
-    let b = core.wrap.mul 0 (2I32, a);
-    return b;
+    return (2I32 * a);
 
 extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), return: Cn [mem.M 0, I32]) =
     let f_diff      = autodiff.ad f;
@@ -20,9 +21,7 @@ extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), retu
             pb(1I32, pb_ret_cont)
             where
                 con pb_ret_cont (pr: I32) =
-                    let c = core.wrap.mul 0 (100I32, r);
-                    let d = core.wrap.add 0 (c, pr);
-                    return (m, d);
+                    return (m, 100I32 * r + pr);
             end;
     end;
 

--- a/lit/autodiff/multiply_autodiff_cond.mim
+++ b/lit/autodiff/multiply_autodiff_cond.mim
@@ -12,11 +12,9 @@ fun f(a: I32): I32 =
     (twice, thrice)#cmp ()
     where
         con twice () =
-            let b = 2I32 * a;
-            return b;
+            return (2I32 * a);
         con thrice () =
-            let b = 3I32 * a;
-            return b;
+            return (3I32 * a);
     end;
 
 extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), return: Cn [mem.M 0, I32]) =

--- a/lit/autodiff/multiply_autodiff_cond.mim
+++ b/lit/autodiff/multiply_autodiff_cond.mim
@@ -5,15 +5,17 @@ plugin core;
 plugin autodiff;
 plugin mem;
 
+use core.ops.s.w;
+
 fun f(a: I32): I32 =
-    let cmp = core.icmp.sle (a, 5I32);
+    let cmp = a <= 5I32;
     (twice, thrice)#cmp ()
     where
         con twice () =
-            let b = core.wrap.mul 0 (2I32, a);
+            let b = 2I32 * a;
             return b;
         con thrice () =
-            let b = core.wrap.mul 0 (3I32, a);
+            let b = 3I32 * a;
             return b;
     end;
 
@@ -27,9 +29,7 @@ extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), retu
             pb (1I32, pb_ret_cont)
             where
                 con pb_ret_cont (pr: I32) =
-                    let c = core.wrap.mul 0 (100I32, r);
-                    let d = core.wrap.add 0 (c, pr);
-                    return (m, d);
+                    return (m, 100I32 * r + pr);
             end;
     end;
 

--- a/lit/autodiff/multiply_autodiff_cond2.mim
+++ b/lit/autodiff/multiply_autodiff_cond2.mim
@@ -5,16 +5,18 @@ plugin core;
 plugin autodiff;
 plugin mem;
 
+use core.ops.s.w;
+
 
 fun f(a: I32): I32 =
-    let cmp = core.icmp.sle (a, 5I32);
+    let cmp = a <= 5I32;
     (twice, thrice)#cmp ()
     where
         con twice () =
-            let b = core.wrap.mul 0 (2I32, a);
+            let b = 2I32 * a;
             return b;
         con thrice () =
-            let b = core.wrap.mul 0 (3I32, a);
+            let b = 3I32 * a;
             return b;
     end;
 
@@ -28,9 +30,7 @@ extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), retu
             pb(1I32, pb_ret_cont)
             where
                 con pb_ret_cont (pr: I32) =
-                    let c = core.wrap.mul 0 (100I32, r);
-                    let d = core.wrap.add 0 (c, pr);
-                    return (m, d);
+                    return (m, 100I32 * r + pr);
             end;
     end;
 

--- a/lit/autodiff/multiply_autodiff_cond2.mim
+++ b/lit/autodiff/multiply_autodiff_cond2.mim
@@ -13,11 +13,9 @@ fun f(a: I32): I32 =
     (twice, thrice)#cmp ()
     where
         con twice () =
-            let b = 2I32 * a;
-            return b;
+            return (2I32 * a);
         con thrice () =
-            let b = 3I32 * a;
-            return b;
+            return (3I32 * a);
     end;
 
 extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), return: Cn [mem.M 0, I32]) =

--- a/lit/autodiff/second/snd_order_man.mim
+++ b/lit/autodiff/second/snd_order_man.mim
@@ -14,7 +14,7 @@ fun g_diff(a: I32): [I32, Fn I32 → I32] =
     return (c, fn (s: I32): I32 =
         let b = 2I32 * a;
         let c = 3I32 + b;
-        return (c));
+        return ((c)));
 
 fun f(a: I32): I32 =
     con ret_cont (r: I32, pb: Fn I32 → I32) =

--- a/lit/autodiff/second/snd_order_man.mim
+++ b/lit/autodiff/second/snd_order_man.mim
@@ -5,14 +5,16 @@ plugin core;
 plugin autodiff;
 plugin mem;
 
+use core.ops.u.w;
+
 
 fun g_diff(a: I32): [I32, Fn I32 → I32] =
-    let b = core.wrap.add 0 (3I32, a);
-    let c = core.wrap.mul 0 (a, b);
+    let b = 3I32 + a;
+    let c = a * b;
     return (c, fn (s: I32): I32 =
-        let b = core.wrap.mul 0 (2I32, a);
-        let c = core.wrap.add 0 (3I32, b);
-        return c);
+        let b = 2I32 * a;
+        let c = 3I32 + b;
+        return (c));
 
 fun f(a: I32): I32 =
     con ret_cont (r: I32, pb: Fn I32 → I32) =
@@ -23,9 +25,7 @@ fun f(a: I32): I32 =
 extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), return: Cn [mem.M 0, I32]) =
     con ret_cont (r: I32, pb: Fn I32 → I32) =
         con pb_ret_cont (pr: I32) =
-            let c = core.wrap.mul 0 (100I32, r);
-            let d = core.wrap.add 0 (c, pr);
-            return (m, d);
+            return (m, 100I32 * r + pr);
         pb(1I32, pb_ret_cont);
 
     let f_diff      = autodiff.ad f;

--- a/lit/autodiff/square.mim
+++ b/lit/autodiff/square.mim
@@ -5,10 +5,11 @@ plugin core;
 plugin autodiff;
 plugin mem;
 
+use core.ops.u.w;
+
 
 fun f(a: I32): I32 =
-    let b = core.wrap.mul 0 (a, a);
-    return b;
+    return (a * a);
 
 extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), return: Cn [mem.M 0, I32]) =
     let f_diff      = autodiff.ad f;
@@ -20,9 +21,7 @@ extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), retu
             pb(1I32, pb_ret_cont)
             where
                 con pb_ret_cont (pr: I32) =
-                    let c = core.wrap.mul 0 (1000I32, r);
-                    let d = core.wrap.add 0 (c, pr);
-                    return (m, d);
+                    return (m, 1000I32 * r + pr);
             end;
     end;
 

--- a/lit/autodiff/square_autodiff.mim
+++ b/lit/autodiff/square_autodiff.mim
@@ -5,9 +5,10 @@ plugin core;
 plugin autodiff;
 plugin mem;
 
+use core.ops.u.w;
+
 fun f(a: I32): I32 =
-    let b = core.wrap.mul 0 (a, a);
-    return b;
+    return (a * a);
 
 extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), return: Cn [mem.M 0, I32]) =
     let f_diff      = autodiff.ad f;
@@ -19,9 +20,7 @@ extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), retu
             pb(1I32, pb_ret_cont)
             where
                 con pb_ret_cont (pr: I32) =
-                    let c = core.wrap.mul 0 (100I32, r);
-                    let d = core.wrap.add 0 (c, pr);
-                    return (m, d);
+                    return (m, 100I32 * r + pr);
             end;
     end;
 

--- a/lit/beta_eq.mim
+++ b/lit/beta_eq.mim
@@ -3,6 +3,8 @@ plugin core;
 plugin math;
 plugin mem;
 
+use core.ops.n;
+
 rec Num = [T: *, add: [T, T] → T];
 lam my_add {pe: «2; Nat»} (a b: math.F pe): math.F pe = math.arith.add 0 (a, b);
 
@@ -16,7 +18,7 @@ extern fun stuff (m: mem.M 0, A: bug.Arr F64): mem.M 0 =
     return m;
 
 lam pow (a b: Nat): Nat =
-    (core.nat.mul (a, pow (a, core.nat.sub (b, 1))), 1)#(core.ncmp.e (b, 0));
+    (a * pow (a, b - 1), 1)#(b == 0);
 
 lam foo (a: «8; Nat»): Bool = tt;
 let _ = foo(‹pow (2, 3); 42›);

--- a/lit/btensor/map_reduce_mult.mim
+++ b/lit/btensor/map_reduce_mult.mim
@@ -6,10 +6,12 @@ plugin btensor;
 plugin buffer;
 plugin mem;
 
+use core.ops.u.w;
+
 
 con inner_fun ((mm: mem.M 0, acc: I32, (a b: I32)), return: Cn [mem.M 0, I32]) =
-    let v       = core.wrap.mul 0 (a, b);
-    let new_acc = core.wrap.add 0 (acc, v); // reduce op = addition
+    let v       = a * b;
+    let new_acc = acc + v; // reduce op = addition
     return (mm, new_acc);
 
 extern con f(mm: mem.M 0,

--- a/lit/btensor/map_reduce_mult_init.mim
+++ b/lit/btensor/map_reduce_mult_init.mim
@@ -6,10 +6,12 @@ plugin btensor;
 plugin buffer;
 plugin mem;
 
+use core.ops.u.w;
+
 
 con g ((mm: mem.M 0, acc: I32, (a b: I32)), return: Cn [mem.M 0, I32]) =
-    let v       = core.wrap.mul 0 (a, b);
-    let new_acc = core.wrap.add 0 (acc, v); // reduce op = addition
+    let v       = a * b;
+    let new_acc = acc + v; // reduce op = addition
     return (mm, new_acc);
 
 extern con f (mm: mem.M 0,

--- a/lit/btensor/map_reduce_mult_init_ret.mim
+++ b/lit/btensor/map_reduce_mult_init_ret.mim
@@ -6,10 +6,12 @@ plugin btensor;
 plugin buffer;
 plugin mem;
 
+use core.ops.u.w;
+
 
 con g ((mm: mem.M 0, acc: I32, (a b: I32)), return: Cn [mem.M 0, I32]) =
-    let v       = core.wrap.mul 0 (a, b);
-    let new_acc = core.wrap.add 0 (acc, v); // reduce op = addition
+    let v       = a * b;
+    let new_acc = acc + v; // reduce op = addition
     return (mm, new_acc);
 
 extern con f (mm: mem.M 0,

--- a/lit/btensor/map_reduce_zip_add.mim
+++ b/lit/btensor/map_reduce_zip_add.mim
@@ -7,10 +7,12 @@ plugin affine;
 plugin buffer;
 plugin mem;
 
+use core.ops.u.w;
+
 
 extern con g ((m: mem.M 0, acc: I32, (a b: I32)), return: Cn [mem.M 0, I32]) =
-    let v       = core.wrap.add 0 (a, b);
-    let new_acc = core.wrap.add 0 (acc, v); // reduce op = addition
+    let v       = a + b;
+    let new_acc = acc + v; // reduce op = addition
     return (m, new_acc);
 
 extern con f (m: mem.M 0,

--- a/lit/buffer/exec_conv.mim
+++ b/lit/buffer/exec_conv.mim
@@ -14,8 +14,10 @@ plugin buffer;
 plugin cps;
 plugin btensor;
 
-lam iadd (a b: I32): I32 = core.wrap.add 0 (a, b);
-lam imul (a b: I32): I32 = core.wrap.mul 0 (a, b);
+use core.ops.u.w;
+
+lam iadd (a b: I32): I32 = a + b;
+lam imul (a b: I32): I32 = a * b;
 let R: tensor.Ring = (I32, 0I32, iadd, imul);
 
 extern fun small (input: «2, 3, 4, 4; I32», w: «2, 3, 3, 3; I32»): «2, 2, 2, 2; I32» =
@@ -27,9 +29,7 @@ extern fun wide (input: «2, 4, 4, 4; I32», w: «2, 4, 3, 3; I32»): «2, 2, 2,
 extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), return: Cn [mem.M 0, I32]) =
     con done_s (os: «2, 2, 2, 2; I32») =
         con done_w (ow: «2, 2, 2, 2; I32») =
-            let vs = tensor.get ((1₂, 1₂, 1₂, 1₂), os);
-            let vw = tensor.get ((0₂, 1₂, 0₂, 1₂), ow);
-            return (m, core.wrap.add 0 (vs, vw));
+            return (m, tensor.get ((1₂, 1₂, 1₂, 1₂), os) + tensor.get ((0₂, 1₂, 0₂, 1₂), ow));
         wide ((‹2; ‹4; ‹4; ‹4; 1I32››››, ‹2; ‹4; ‹3; ‹3; 1I32››››), done_w);
     small ((‹2; ‹3; ‹4; ‹4; 1I32››››, ‹2; ‹3; ‹3; ‹3; 1I32››››), done_s);
 

--- a/lit/buffer/exec_epilogue.mim
+++ b/lit/buffer/exec_epilogue.mim
@@ -19,9 +19,11 @@ plugin cps;
 plugin btensor;
 plugin buffer;
 
-fun add (x: I32, y: «1; I32»)@tt = return (core.wrap.add 0 (x, y#0₁));
-lam addb (x y: I32): I32 = core.wrap.add 0 (x, y);
-lam add1 (x: I32): I32 = core.wrap.add 0 (x, 1I32);
+use core.ops.u.w;
+
+fun add (x: I32, y: «1; I32»)@tt = return (x + y#0₁);
+lam addb (x y: I32): I32 = x + y;
+lam add1 (x: I32): I32 = x + 1I32;
 lam id1i (i j: affine.Index): «1; affine.Index» = i;
 lam id2  (i j: affine.Index): «2; affine.Index» = (i, j);
 
@@ -30,15 +32,13 @@ extern fun row_sum1 (input: «4, 3; I32», bias: «3; I32»): «3; I32» =
     let t      = tensor.transpose_2d input;
     let sums   = tensor.map_reduce (3, (3, 4))
                      (add, 0I32) id1i id2 t;
-    let biased = tensor.binary addb (sums, bias);
-    return (tensor.unary add1 biased);
+    return (tensor.unary add1 (tensor.binary addb (sums, bias)));
 
 extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), return: Cn [mem.M 0, I32]) =
     let t = ((1I32, 5I32, 9I32), (2I32, 6I32, 10I32), (3I32, 7I32, 11I32), (4I32, 8I32, 12I32));
     let bias = (1I32, 2I32, 3I32);
     con done (o: «3; I32») =
-        let v = tensor.get ((2₃, ), o);
-        return (m, v);
+        return (m, tensor.get ((2₃, ), o));
     row_sum1 ((t, bias), done);
 
 // CHECK-DAG: mem.load

--- a/lit/buffer/exec_get_set.mim
+++ b/lit/buffer/exec_get_set.mim
@@ -14,12 +14,14 @@ plugin tensor;
 plugin mem;
 plugin buffer;
 
+use core.ops.u.w;
+
 extern fun kernel (t: «3, 4; I32», i: [Idx 3, Idx 4]): I32 =
     let s = tensor.set ((0₃, 0₄), t, 42I32);
     let a = tensor.get ((0₃, 0₄), s);
     let b = tensor.get (i, s);
     let c = tensor.get ((0₃, 0₄), t);
-    return (core.wrap.add 0 (a, core.wrap.add 0 (b, c)));
+    return (a + (b + c));
 
 extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), return: Cn [mem.M 0, I32]) =
     let t = ((1I32, 2I32, 3I32, 4I32), (5I32, 6I32, 7I32, 8I32), (9I32, 10I32, 11I32, 12I32));

--- a/lit/buffer/exec_ktile.mim
+++ b/lit/buffer/exec_ktile.mim
@@ -14,8 +14,10 @@ plugin buffer;
 plugin cps;
 plugin btensor;
 
-lam iadd (a b: I32): I32 = core.wrap.add 0 (a, b);
-lam imul (a b: I32): I32 = core.wrap.mul 0 (a, b);
+use core.ops.u.w;
+
+lam iadd (a b: I32): I32 = a + b;
+lam imul (a b: I32): I32 = a * b;
 let R: tensor.Ring = (I32, 0I32, iadd, imul);
 
 extern fun mm (a: «2, 4; I32», b: «4, 2; I32»): «2, 2; I32» =

--- a/lit/buffer/exec_tile.mim
+++ b/lit/buffer/exec_tile.mim
@@ -16,8 +16,10 @@ plugin buffer;
 plugin cps;
 plugin btensor;
 
+use core.ops.u.w;
+
 fun mul_add (acc: I32, ab: «2; I32»)@tt =
-    return (core.wrap.add 0 (acc, core.wrap.mul 0 (ab#0₂, ab#1₂)));
+    return (acc + ab#0₂ * ab#1₂);
 
 extern fun gemm (a: «4, 8; I32», b: «8, 4; I32»): «2, 2, 2, 2; I32» =
     return (tensor.materialize (tensor.interchange (
@@ -41,8 +43,7 @@ extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), retu
     let a = (‹8; 1I32›, ‹8; 2I32›, ‹8; 3I32›, ‹8; 4I32›);
     let b = ‹8; (1I32, 3I32, 5I32, 7I32)›;
     con done (o: «2, 2, 2, 2; I32») =
-        let v = tensor.get ((0₂, 1₂, 1₂, 0₂), o);
-        return (m, v);
+        return (m, tensor.get ((0₂, 1₂, 1₂, 0₂), o));
     gemm ((a, b), done);
 
 // GONE-NOT: %tensor.

--- a/lit/buffer/exec_weak_sched.mim
+++ b/lit/buffer/exec_weak_sched.mim
@@ -18,7 +18,9 @@ plugin buffer;
 plugin btensor;
 plugin cps;
 
-fun add (x y: I32)@tt = return (core.wrap.add 0 (x, y));
+use core.ops.u.w;
+
+fun add (x y: I32)@tt = return (x + y);
 lam mo (i j k a: affine.Index): «3; affine.Index» = (i, j, k);
 lam mi (i j k a: affine.Index): «4; affine.Index» = (i, j, k, a);
 
@@ -42,7 +44,6 @@ extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), retu
     con done1 (o: «2, 3, 4; I32») =
         let v1 = tensor.get ((1₂, 2₃, 3₄), o);
         con done2 (o: «2, 3, 4; I32») =
-            let v2 = tensor.get ((1₂, 2₃, 3₄), o);
-            return (m, core.wrap.add 0 (v1, v2));
+            return (m, v1 + tensor.get ((1₂, 2₃, 3₄), o));
         sum_over_unroll (t, done2);
     sum_weak_vdim (t, done1);

--- a/lit/buffer/tensor_map_reduce.mim
+++ b/lit/buffer/tensor_map_reduce.mim
@@ -19,7 +19,9 @@ plugin btensor;
 plugin opt;
 plugin compile;
 
-fun add  (x: I32, y: «1; I32»)@tt = return (core.wrap.add 0 (x, y#0₁));
+use core.ops.u.w;
+
+fun add  (x: I32, y: «1; I32»)@tt = return (x + y#0₁);
 fun copy (x: I32, y: «1; I32»)@tt = return (y#0₁);
 lam id1 (i: affine.Index): «1; affine.Index» = i;
 lam id1i(i, j: affine.Index): «1; affine.Index» = i;

--- a/lit/buffer/two_same_shape_binary.mim
+++ b/lit/buffer/two_same_shape_binary.mim
@@ -25,8 +25,10 @@ plugin btensor;
 plugin buffer;
 plugin cps;
 
-lam i32_add (a b: I32): I32 = core.wrap.add 0 (a, b);
-lam i32_sub (a b: I32): I32 = core.wrap.sub 0 (a, b);
+use core.ops.u.w;
+
+lam i32_add (a b: I32): I32 = a + b;
+lam i32_sub (a b: I32): I32 = a - b;
 
 extern fun kernel (x y: «3, 4; I32», i j: [Idx 6, Idx 4]): I32 =
     let a  = tensor.binary i32_add (x, y);
@@ -34,7 +36,7 @@ extern fun kernel (x y: «3, 4; I32», i j: [Idx 6, Idx 4]): I32 =
     let c  = tensor.concat 0₂ (a, b);
     let ga = tensor.get (i, c);
     let gb = tensor.get (j, c);
-    return (core.wrap.add 0 (ga, gb));
+    return (ga + gb);
 
 extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), return: Cn [mem.M 0, I32]) =
     let x = ((10I32, 1I32, 2I32, 3I32), (4I32, 5I32, 30I32, 7I32), (8I32, 9I32, 10I32, 11I32));

--- a/lit/clos/array.mim
+++ b/lit/clos/array.mim
@@ -5,16 +5,18 @@ plugin core;
 plugin clos;
 plugin mem;
 
+use core.ops.u.w;
+
 
 con f (m: mem.M 0, x: I32, return: Cn [mem.M 0, I32]) =
-    return (m, core.wrap.add 0 (x, 42I32));
+    return (m, x + 42I32);
 
 con g (m: mem.M 0, x: I32, return: Cn [mem.M 0, I32]) =
     return (m, 1I32);
 
 
 extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr («⊤:Nat; mem.Ptr («⊤:Nat; I8», 0)», 0), return: Cn [mem.M 0, I32]) =
-    con h (m: mem.M 0, x: I32, return: Cn [mem.M 0, I32]) = return (m, core.wrap.add 0 (x, argc));
+    con h (m: mem.M 0, x: I32, return: Cn [mem.M 0, I32]) = return (m, x + argc);
 
     let pb_type = Cn [mem.M 0, I32, Cn [mem.M 0, I32]];
     let Tas = (pb_type, 0);
@@ -33,8 +35,7 @@ extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr («⊤:Nat; mem.Ptr («⊤
     let lea   = mem.lea (a_arr, 0₄);
     let m   = mem.store (m, lea, 10I32);
 
-    let fn_lea      = mem.lea (pb_arr, 2₄);
-    let (m, func) = mem.load (m, fn_lea);
+    let (m, func) = mem.load (m, mem.lea (pb_arr, 2₄));
     let (m, _)    = mem.load (m, lea);
     func(m, 1I32, callback)
     where

--- a/lit/clos/bind.mim
+++ b/lit/clos/bind.mim
@@ -6,20 +6,22 @@
 plugin mem;
 plugin core;
 
+use core.ops.u.w;
+
 let pb_type = Cn [mem.M 0, Cn [mem.M 0]];
 let size    = 100;
 
 extern con println_i32 [m: mem.M 0, val: I32, return: Cn [mem.M 0]];
 
 con recursive (m: mem.M 0, i: I32, last_pullback: pb_type, return: Cn [mem.M 0]) =
-    let condition = core.icmp.ul (i, core.bitcast I32 size);
+    let condition = i < core.bitcast I32 size;
     (exit, loop_body)#condition m
     where
         con loop_body (m: mem.M 0) =
             println_i32( m, i , next )
             where
                 con next (m: mem.M 0) =
-                    recursive( m, core.wrap.add 0 (i, 1I32), pb, return )
+                    recursive( m, i + 1I32, pb, return )
                     where
                         con pb (m: mem.M 0, return: Cn [mem.M 0]) =
                             println_i32( m, i , next )

--- a/lit/clos/loopDiff.mim
+++ b/lit/clos/loopDiff.mim
@@ -4,6 +4,8 @@
 plugin core;
 plugin mem;
 
+use core.ops.u.w;
+
 let void_ptr = mem.Ptr («⊤:Nat; []», 0);
 
 extern con printInteger [m: mem.M 0, val: I32, return: Cn [mem.M 0]];
@@ -18,7 +20,7 @@ con printArr (m: mem.M 0, arr: mem.Ptr («size; I32», 0), return: Cn [mem.M 0])
     loop_head ( m, 0I32 )
     where
         con loop_head (m: mem.M 0, i: I32) =
-            let condition = core.icmp.ul (i, core.bitcast I32 size);
+            let condition = i < core.bitcast I32 size;
             (exit, enter)#condition m
             where
                 con enter (m: mem.M 0) =
@@ -28,7 +30,7 @@ con printArr (m: mem.M 0, arr: mem.Ptr («size; I32», 0), return: Cn [mem.M 0])
                             let lea = mem.lea (arr, core.bitcast (Idx size) i);
                             let (load_mem, val) = mem.load (m, lea);
                             printInteger(load_mem, val, continue);
-                        con yield (m: mem.M 0) = loop_head( m, core.wrap.add 0 (i, 1I32));
+                        con yield (m: mem.M 0) = loop_head( m, i + 1I32);
                     end;
                 con exit(m: mem.M 0) = printNL (m, return);
             end;
@@ -38,15 +40,15 @@ con init (m: mem.M 0, arr: mem.Ptr («size; I32», 0), offset: I32, return: Cn [
     loop_head ( m, 0I32 )
     where
         con loop_head (m: mem.M 0, i: I32) =
-            con yield (m: mem.M 0) = loop_head( m, core.wrap.add 0 (i, 1I32));
+            con yield (m: mem.M 0) = loop_head( m, i + 1I32);
             con enter (m: mem.M 0) = loop_body ( m, i, yield );
 
-            let condition = core.icmp.ul (i, core.bitcast I32 size);
+            let condition = i < core.bitcast I32 size;
             let target = (return, enter)#condition;
             target m;
         con loop_body (m: mem.M 0, i: I32, continue: Cn mem.M 0) =
             let lea = mem.lea (arr, core.bitcast (Idx size) i);
-            let add = core.wrap.add 0 (offset, i);
+            let add = offset + i;
             let store_mem = mem.store (m, lea, add);
             continue(store_mem);
     end;
@@ -58,10 +60,10 @@ con const (m: mem.M 0, arr: mem.Ptr («size; I32», 0), constValue: I32, return:
         continue(store_mem);
 
     con loop_head (m: mem.M 0, i: I32) =
-        con yield (m: mem.M 0) = loop_head( m, core.wrap.add 0 (i, 1I32));
+        con yield (m: mem.M 0) = loop_head( m, i + 1I32);
         con enter (m: mem.M 0) = loop_body ( m, i, yield );
 
-        let condition = core.icmp.ul (i, core.bitcast I32 size);
+        let condition = i < core.bitcast I32 size;
         let target = (return, enter)#condition;
         target ( m );
 
@@ -94,7 +96,7 @@ con outer (m: mem.M 0, x: I32, return: Cn [mem.M 0]) =
         let (a_load_mem, a_val) = mem.load (m, a_lea);
         let (b_load_mem, b_val) = mem.load (a_load_mem, b_lea);
 
-        let prod = core.wrap.mul 0 (a_val, b_val);
+        let prod = a_val * b_val;
 
         let c_store_mem = mem.store (b_load_mem, c_lea, prod);
 
@@ -109,19 +111,18 @@ con outer (m: mem.M 0, x: I32, return: Cn [mem.M 0]) =
             let cd_store_mem = mem.store (cd_load_mem, cd_lea, 0I32);
 
             let (ad_load_mem, ad_val) = mem.load (cd_store_mem, ad_lea);
-            let cd_b_mul = core.wrap.mul 0 (cd_val, b_val);
-            let ad_b_add = core.wrap.add 0 (ad_val, cd_b_mul);
+            let cd_b_mul = cd_val * b_val;
+            let ad_b_add = ad_val + cd_b_mul;
             let ad_store_mem = mem.store (ad_load_mem, ad_lea, ad_b_add);
 
             let (bd_load_mem, bd_val) = mem.load (ad_store_mem, bd_lea);
-            let cd_a_mul = core.wrap.mul 0 (cd_val, a_val);
-            let bd_a_add = core.wrap.add 0 (bd_val, cd_a_mul);
+            let cd_a_mul = cd_val * a_val;
+            let bd_a_add = bd_val + cd_a_mul;
             let bd_store_mem = mem.store (bd_load_mem, bd_lea, bd_a_add);
 
             last_pb (bd_store_mem, end_);
 
-        let store_pb_mem = mem.store (load_pb_mem, lea_pb, pb);
-        return(store_pb_mem);
+        return(mem.store (load_pb_mem, lea_pb, pb));
 
     con print_c (m: mem.M 0) = printArr(m, c_arr, return);
     con print_b (m: mem.M 0) = printArr(m, b_arr, print_c);
@@ -143,11 +144,11 @@ con outer (m: mem.M 0, x: I32, return: Cn [mem.M 0]) =
 
             con yield (m: mem.M 0) =
                 // loop_head( mem, core.wrap.add (0, i32) (i, 1I32))
-                loop_head( m, core.wrap.add 0 (i, 1I32));
+                loop_head( m, i + 1I32);
 
             con enter (m: mem.M 0) = loop_body ( m, i, yield );
 
-            let condition = core.icmp.ul (i, core.bitcast I32 size);
+            let condition = i < core.bitcast I32 size;
             let target = (exit, enter)#condition;
             target ( m );
         loop_head ( m, 0I32 );

--- a/lit/clos/loopDiff2.mim
+++ b/lit/clos/loopDiff2.mim
@@ -96,15 +96,13 @@ con outer (m: mem.M 0, x: I32, return: Cn [mem.M 0]) =
             let ad_lea = mem.lea (ad_arr, core.bitcast (Idx arr_size) i);
             let (load_mem, val) = mem.load (m, ad_lea);
             let new_val = val + s;
-            let store_mem = mem.store (load_mem, ad_lea, new_val);
-            return store_mem;
+            return (mem.store (load_mem, ad_lea, new_val));
 
         con right_pb (m: mem.M 0, s: I32, return: Cn [mem.M 0]) =
             let bd_lea = mem.lea (bd_arr, core.bitcast (Idx arr_size) i);
             let (load_mem, val) = mem.load (m, bd_lea);
             let new_val = val + s;
-            let store_mem = mem.store (load_mem, bd_lea, new_val);
-            return store_mem;
+            return (mem.store (load_mem, bd_lea, new_val));
 
         con mul_pb (m: mem.M 0, s: I32, return: Cn [mem.M 0]) =
             let sa_mul = s * b_val;

--- a/lit/clos/loopDiff2.mim
+++ b/lit/clos/loopDiff2.mim
@@ -4,6 +4,8 @@
 plugin core;
 plugin mem;
 
+use core.ops.u.w;
+
 let void_ptr = mem.Ptr («⊤:Nat; []», 0);
 
 extern con printInteger [m: mem.M 0, val: I32, return: Cn [mem.M 0]];
@@ -21,11 +23,11 @@ con printArr (m: mem.M 0, arr: mem.Ptr («size; I32», 0), return: Cn [mem.M 0])
         printInteger(load_mem, val, continue);
 
     con loop_head (m: mem.M 0, i: I32) =
-        con yield (m: mem.M 0) = loop_head( m, core.wrap.add 0 (i, 1I32));
+        con yield (m: mem.M 0) = loop_head( m, i + 1I32);
         con enter (m: mem.M 0) = loop_body ( m, i, yield );
         con exit (m: mem.M 0) = printNL (m, return);
 
-        let condition = core.icmp.ul (i, core.bitcast I32 size);
+        let condition = i < core.bitcast I32 size;
         let target = (exit, enter)#condition;
         target ( m );
 
@@ -34,15 +36,15 @@ con printArr (m: mem.M 0, arr: mem.Ptr («size; I32», 0), return: Cn [mem.M 0])
 con init (m: mem.M 0, arr: mem.Ptr («size; I32», 0), offset: I32, return: Cn [mem.M 0]) =
     con loop_body (m: mem.M 0, i: I32, continue: Cn mem.M 0) =
         let lea = mem.lea (arr, core.bitcast (Idx arr_size) i);
-        let add = core.wrap.add 0 (offset, i);
+        let add = offset + i;
         let store_mem = mem.store (m, lea, add);
         continue(store_mem);
 
     con loop_head (m: mem.M 0, i: I32) =
-        con yield (m: mem.M 0) = loop_head( m, core.wrap.add 0 (i, 1I32));
+        con yield (m: mem.M 0) = loop_head( m, i + 1I32);
         con enter (m: mem.M 0) = loop_body ( m, i, yield );
 
-        let condition = core.icmp.ul (i, core.bitcast I32 size);
+        let condition = i < core.bitcast I32 size;
         let target = (return, enter)#condition;
         target ( m );
 
@@ -55,10 +57,10 @@ con const (m: mem.M 0, arr: mem.Ptr («size; I32», 0), constValue: I32, return:
         continue(store_mem);
 
     con loop_head (m: mem.M 0, i: I32) =
-        con yield (m: mem.M 0) = loop_head( m, core.wrap.add 0 (i, 1I32));
+        con yield (m: mem.M 0) = loop_head( m, i + 1I32);
         con enter (m: mem.M 0) = loop_body ( m, i, yield );
 
-        let condition = core.icmp.ul (i, core.bitcast I32 size);
+        let condition = i < core.bitcast I32 size;
         let target = (return, enter)#condition;
         target ( m );
 
@@ -86,30 +88,29 @@ con outer (m: mem.M 0, x: I32, return: Cn [mem.M 0]) =
         let (a_load_mem, a_val) = mem.load (m, a_lea);
         let (b_load_mem, b_val) = mem.load (a_load_mem, b_lea);
 
-        let prod = core.wrap.mul 0 (a_val, b_val);
+        let prod = a_val * b_val;
 
         let c_store_mem = mem.store (b_load_mem, c_lea, prod);
 
         con left_pb (m: mem.M 0, s: I32, return: Cn [mem.M 0]) =
             let ad_lea = mem.lea (ad_arr, core.bitcast (Idx arr_size) i);
             let (load_mem, val) = mem.load (m, ad_lea);
-            let new_val = core.wrap.add 0 (val, s);
+            let new_val = val + s;
             let store_mem = mem.store (load_mem, ad_lea, new_val);
             return store_mem;
 
         con right_pb (m: mem.M 0, s: I32, return: Cn [mem.M 0]) =
             let bd_lea = mem.lea (bd_arr, core.bitcast (Idx arr_size) i);
             let (load_mem, val) = mem.load (m, bd_lea);
-            let new_val = core.wrap.add 0 (val, s);
+            let new_val = val + s;
             let store_mem = mem.store (load_mem, bd_lea, new_val);
             return store_mem;
 
         con mul_pb (m: mem.M 0, s: I32, return: Cn [mem.M 0]) =
-            let sa_mul = core.wrap.mul 0 (s, b_val);
+            let sa_mul = s * b_val;
 
             con next (m: mem.M 0) =
-                let sb_mul = core.wrap.mul 0 (s, a_val);
-                right_pb(m, sb_mul, return);
+                right_pb(m, s * a_val, return);
 
             left_pb( m, sa_mul,  next);
 
@@ -133,23 +134,23 @@ con outer (m: mem.M 0, x: I32, return: Cn [mem.M 0]) =
             // print_ad(mem)
 
         con backward_loop_head (m: mem.M 0, i: I32) =
-            con yield (m: mem.M 0) = backward_loop_head( m, core.wrap.add 0 (i, 1I32 ) );
+            con yield (m: mem.M 0) = backward_loop_head( m, i + 1I32 );
 
             con enter (m: mem.M 0) =
                 let lea_pb = mem.lea (pb_arr, core.bitcast (Idx arr_size) i);
                 let (backward_pass_mem, backward_pass) = mem.load (m, lea_pb);
                 backward_pass ( backward_pass_mem, 1I32, yield );
 
-            let condition = core.icmp.ul (i, core.bitcast I32 size);
+            let condition = i < core.bitcast I32 size;
             let target = (timer, enter)#condition;
             target ( m );
 
         con loop_head (m: mem.M 0, i: I32) =
             con exit (m: mem.M 0) = backward_loop_head(m, 0I32);
-            con yield (m: mem.M 0) = loop_head( m, core.wrap.add 0 (i, 1I32));
+            con yield (m: mem.M 0) = loop_head( m, i + 1I32);
             con enter (m: mem.M 0) = loop_body ( m, i, yield );
 
-            let condition = core.icmp.ul (i, core.bitcast I32 size);
+            let condition = i < core.bitcast I32 size;
             let target = (exit, enter)#condition;
             target ( m );
         loop_head ( m, 0I32 );

--- a/lit/clos/loopDiffSave.mim
+++ b/lit/clos/loopDiffSave.mim
@@ -4,6 +4,8 @@
 plugin core;
 plugin mem;
 
+use core.ops.u.w;
+
 extern con printInteger [m: mem.M 0, val: I32, return: Cn [mem.M 0]];
 
 let arr_size = ⊤:Nat;
@@ -11,14 +13,13 @@ let arr_size = ⊤:Nat;
 con init (m: mem.M 0, arr: mem.Ptr («4; I32», 0), return: Cn [mem.M 0]) =
     con loop_body (m: mem.M 0, i: I32, continue: Cn mem.M 0) =
         let lea = mem.lea (arr, core.bitcast (Idx arr_size) i);
-        let store_mem = mem.store (m, lea, i);
-        continue(store_mem);
+        continue(mem.store (m, lea, i));
 
     con loop_head (m: mem.M 0, i: I32) =
-        con yield (m: mem.M 0) = loop_head( m, core.wrap.add 0 (i, 1I32));
+        con yield (m: mem.M 0) = loop_head( m, i + 1I32);
         con enter (m: mem.M 0) = loop_body ( m, i, yield );
 
-        let condition = core.icmp.ul (i, 19I32);
+        let condition = i < 19I32;
         let target = (return, enter)#condition;
         target ( m );
 
@@ -36,8 +37,7 @@ con outer (m: mem.M 0, x: I32, return: Cn [mem.M 0, I32]) =
     // TODO: check if fix is correct
     con finish_pb_trace (m: mem.M 0, return: Cn mem.M 0) = return m;
 
-    let pb_type = Cn [mem.M 0, Cn [mem.M 0]];
-    let (alloc_pb_mem, pb_ptr) = mem.malloc (pb_type, 0) (m, 32);
+    let (alloc_pb_mem, pb_ptr) = mem.malloc (Cn [mem.M 0, Cn [mem.M 0]], 0) (m, 32);
 
     let pb_arr = core.bitcast (mem.Ptr («⊤:Nat; Cn [mem.M 0, Cn [mem.M 0]]», 0)) pb_ptr;
     let lea_pb = mem.lea (pb_arr, core.bitcast (Idx arr_size) 0I32);
@@ -51,7 +51,7 @@ con outer (m: mem.M 0, x: I32, return: Cn [mem.M 0, I32]) =
         let (a_load_mem, a_val) = mem.load (m, a_lea);
         let (b_load_mem, b_val) = mem.load (a_load_mem, a_lea);
 
-        let prod = core.wrap.mul 0 (a_val, b_val);
+        let prod = a_val * b_val;
 
         let c_store_mem = mem.store (b_load_mem, c_lea, prod);
 
@@ -64,13 +64,11 @@ con outer (m: mem.M 0, x: I32, return: Cn [mem.M 0, I32]) =
             let cd_store_mem = mem.store (cd_load_mem, cd_lea, 0I32);
 
             let (ad_load_mem, ad_val) = mem.load (cd_store_mem, ad_lea);
-            let ad_b_add = core.wrap.add 0 (ad_val, b_val);
+            let ad_b_add = ad_val + b_val;
             let ad_store_mem = mem.store (ad_load_mem, ad_lea, ad_b_add);
 
             let (bd_load_mem, bd_val) = mem.load (ad_store_mem, bd_lea);
-            let bd_a_add = core.wrap.add 0 (bd_val, a_val);
-            let bd_store_mem = mem.store (bd_load_mem, bd_lea, bd_a_add);
-            return (bd_store_mem);
+            return (mem.store (bd_load_mem, bd_lea, bd_val + a_val));
 
         printInteger(c_store_mem, prod, continue);
         //continue(c_store_mem)
@@ -78,10 +76,10 @@ con outer (m: mem.M 0, x: I32, return: Cn [mem.M 0, I32]) =
     con loop_head (m: mem.M 0, i: I32) =
         // TODO: check if fix is correct
         con exit (m: mem.M 0) = return (m, i);
-        con yield(m: mem.M 0) = loop_head( m, core.wrap.add 0 (i, 1I32));
+        con yield(m: mem.M 0) = loop_head( m, i + 1I32);
         con enter(m: mem.M 0) = loop_body ( m, i, yield );
 
-        let condition = core.icmp.ul (i, 19I32);
+        let condition = i < 19I32;
         let target = (exit, enter)#condition;
         target ( m );
 

--- a/lit/clos/loopError.mim
+++ b/lit/clos/loopError.mim
@@ -4,18 +4,19 @@
 plugin core;
 plugin mem;
 
+use core.ops.u.w;
+
 extern con printInteger [m: mem.M 0, val: I32, return: Cn [mem.M 0]];
 
 let arr_size = ⊤:Nat;
 
 con init (m: mem.M 0, return: Cn [mem.M 0]) =
     con loop_head (m: mem.M 0, i: I32) =
-        con yield (m: mem.M 0) = loop_head( m, core.wrap.add 0 (i, 1I32) );;
+        con yield (m: mem.M 0) = loop_head( m, i + 1I32 );;
         con print (m: mem.M 0) = printInteger( m, i, yield );
 
-        let condition = core.icmp.ul (i, 42I32);
-        let target = (return, print)#condition;
-        target ( m );
+        let condition = i < 42I32;
+        (return, print)#condition ( m );
     loop_head ( m, 0I32 );
 
 extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr («⊤:Nat; mem.Ptr («⊤:Nat; I8», 0)», 0), return: Cn [mem.M 0, I32]) =

--- a/lit/clos/malloc.mim
+++ b/lit/clos/malloc.mim
@@ -4,12 +4,14 @@
 plugin core;
 plugin mem;
 
+use core.ops.u.w;
 
-con f (m: mem.M 0, x: I32, return: Cn [mem.M 0, I32]) = return (m, core.wrap.add 0 (x, 42I32));
+
+con f (m: mem.M 0, x: I32, return: Cn [mem.M 0, I32]) = return (m, x + 42I32);
 con g (m: mem.M 0, x: I32, return: Cn [mem.M 0, I32]) = return (m, 1I32);
 
 extern fun main(m: mem.M 0, argc: I32, argv: mem.Ptr («⊤:Nat; mem.Ptr («⊤:Nat; I8», 0)», 0)): [mem.M 0, I32] =
-    con h(m: mem.M 0, x: I32, return: Cn [mem.M 0, I32]) = return (m, core.wrap.add 0 (x, argc));
+    con h(m: mem.M 0, x: I32, return: Cn [mem.M 0, I32]) = return (m, x + argc);
 
     let pb_type  = Cn [mem.M 0, I32, Cn [mem.M 0, I32]];
     let Tas      = (pb_type, 0);

--- a/lit/clos/no_mem_escaping.mim
+++ b/lit/clos/no_mem_escaping.mim
@@ -43,7 +43,7 @@ extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), retu
                 println_i32 (m, r0, cn (m: mem.M 0) =
                     println_i32 (m, r1, cn (m: mem.M 0) =
                         println_i32 (m, r2, cn (m: mem.M 0) =
-                            return ((m, 0I32))))))));
+                            return (((m, 0I32)))))))));
 
 // CHECK: 43
 // CHECK: 1

--- a/lit/clos/no_mem_escaping.mim
+++ b/lit/clos/no_mem_escaping.mim
@@ -11,13 +11,15 @@
 plugin core;
 plugin mem;
 
+use core.ops.u.w;
+
 extern con println_i32 [m: mem.M 0, val: I32, return: Cn [mem.M 0]];
 
-con f (x: I32, k: Cn I32) = k (core.wrap.add 0 (x, 42I32));
+con f (x: I32, k: Cn I32) = k (x + 42I32);
 con g (x: I32, k: Cn I32) = k (1I32);
 
 extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), return: Cn [mem.M 0, I32]) =
-    con h (x: I32, k: Cn I32) = k (core.wrap.add 0 (x, argc));
+    con h (x: I32, k: Cn I32) = k (x + argc);
 
     let pb_type = Cn [I32, Cn I32];
 
@@ -31,12 +33,9 @@ extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), retu
     let lea = mem.lea (pb_arr, core.idx_unsafe 2);
     let m = mem.store (m, lea, h);
 
-    let lea0 = mem.lea (pb_arr, core.idx_unsafe 0);
-    let (m, func0) = mem.load (m, lea0);
-    let lea1 = mem.lea (pb_arr, core.idx_unsafe 1);
-    let (m, func1) = mem.load (m, lea1);
-    let lea2 = mem.lea (pb_arr, core.idx_unsafe 2);
-    let (m, func2) = mem.load (m, lea2);
+    let (m, func0) = mem.load (m, mem.lea (pb_arr, core.idx_unsafe 0));
+    let (m, func1) = mem.load (m, mem.lea (pb_arr, core.idx_unsafe 1));
+    let (m, func2) = mem.load (m, mem.lea (pb_arr, core.idx_unsafe 2));
 
     func0 (1I32, cn (r0: I32) =
         func1 (1I32, cn (r1: I32) =
@@ -44,7 +43,7 @@ extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), retu
                 println_i32 (m, r0, cn (m: mem.M 0) =
                     println_i32 (m, r1, cn (m: mem.M 0) =
                         println_i32 (m, r2, cn (m: mem.M 0) =
-                            return (m, 0I32)))))));
+                            return ((m, 0I32))))))));
 
 // CHECK: 43
 // CHECK: 1

--- a/lit/clos/pass_through_return.mim
+++ b/lit/clos/pass_through_return.mim
@@ -5,6 +5,8 @@ plugin core;
 plugin cps;
 plugin mem;
 
+use core.ops.u.w;
+
 let pb_type = Cn [mem.M 0, Cn [mem.M 0]];
 
 fun end_(m: mem.M 0): mem.M 0 = return m;
@@ -24,7 +26,7 @@ extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr («⊤:Nat; mem.Ptr («⊤
             let (backward_pass_mem, backward_pass) = mem.load (m, lea_pb); // <- begin backward pass
             backward_pass (backward_pass_mem, callback);
 
-        con yield (m: mem.M 0) = loop_head( m, core.wrap.add 0 (i, 1I32) );
+        con yield (m: mem.M 0) = loop_head( m, i + 1I32 );
 
         con body (m: mem.M 0) =
             let (load_pb_mem, last_pb) = mem.load (m, lea_pb);
@@ -37,8 +39,7 @@ extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr («⊤:Nat; mem.Ptr («⊤
 
             printInteger(store_pb_mem, i, yield);
 
-        let condition = core.icmp.ul (i, 19I32);
-        let target = (exit, body)#condition;
-        target ( m );
+        let condition = i < 19I32;
+        (exit, body)#condition ( m );
 
     loop_head ( store_pb, 0I32 ); // <-- start forward pass

--- a/lit/clos/recursiveLoop.mim
+++ b/lit/clos/recursiveLoop.mim
@@ -5,6 +5,8 @@ plugin core;
 plugin cps;
 plugin mem;
 
+use core.ops.u.w;
+
 let pb_type = Cn [mem.M 0, Cn [mem.M 0]];
 
 extern con printInteger [m: mem.M 0, val: I32, return: Cn [mem.M 0]];
@@ -14,7 +16,7 @@ extern con printNL [m: mem.M 0, return: Cn [mem.M 0]];
 let size = 10;
 
 con recursive (m: mem.M 0, i: I32, last_pullback: pb_type, return: Cn [mem.M 0]) =
-    let condition = core.icmp.ul (i, core.bitcast I32 size);
+    let condition = i < core.bitcast I32 size;
     (exit, loop_body)#condition m
     where
         con loop_body (m: mem.M 0) =
@@ -26,7 +28,7 @@ con recursive (m: mem.M 0, i: I32, last_pullback: pb_type, return: Cn [mem.M 0])
 
             printIntegerNL (m, i , next)
             where
-                con next (m: mem.M 0) = recursive( m, core.wrap.add 0 (i, 1I32), pb, return );
+                con next (m: mem.M 0) = recursive( m, i + 1I32, pb, return );
             end;
         con exit (m: mem.M 0) = last_pullback (m, return);
     end;

--- a/lit/clos/return_cont_in_closure.mim
+++ b/lit/clos/return_cont_in_closure.mim
@@ -5,6 +5,8 @@ plugin core;
 plugin cps;
 plugin mem;
 
+use core.ops.u.w;
+
 let pb_type = Cn [mem.M 0];
 
 extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr («⊤:Nat; mem.Ptr («⊤:Nat; I8», 0)», 0), return: Cn [mem.M 0, I32]) =
@@ -20,7 +22,7 @@ extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr («⊤:Nat; mem.Ptr («⊤
             let (backward_pass_mem, backward_pass) = mem.load (m, lea_pb); // <- begin backward pass
             backward_pass (backward_pass_mem);
 
-        con yield (m: mem.M 0) = loop_head( m, core.wrap.add 0 (i, 1I32) );
+        con yield (m: mem.M 0) = loop_head( m, i + 1I32 );
 
         con body (m: mem.M 0) =
             let (load_pb_mem, last_pb) = mem.load (m, lea_pb);
@@ -29,8 +31,7 @@ extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr («⊤:Nat; mem.Ptr («⊤
             let store_pb_mem = mem.store (load_pb_mem, lea_pb, pb);  // << stack backward pass block
             yield(store_pb_mem);
 
-        let condition = core.icmp.ul (i, 19I32);
-        let target = (exit, body)#condition;
-        target ( m );
+        let condition = i < 19I32;
+        (exit, body)#condition ( m );
 
     loop_head ( store_pb, 0I32 ); // <-- start forward pass

--- a/lit/clos/return_higher_order_pow.mim
+++ b/lit/clos/return_higher_order_pow.mim
@@ -7,6 +7,8 @@
 plugin core;
 plugin mem;
 
+use core.ops.u.w;
+
 let PbVec  = Cn [mem.M 0, «2; I32»];    // innermost pullback continuation
 let Pb     = Cn [mem.M 0, I32, PbVec];  // pullback
 let AugRet = Cn [mem.M 0, I32, Pb];     // augmented return continuation
@@ -26,17 +28,14 @@ con aug_f (m: mem.M 0, x: I32, aug_ret: AugRet) =
             con fwd (m: mem.M 0, v: «2; I32») = pb_ret (m, v);
             con comp_cont (m: mem.M 0, ab: [I32, I32]) @tt =
                 let (a, b) = ab;
-                let p = core.wrap.mul 0 (r, s);
-                let q = core.wrap.add 0 (p, a);
-                fwd (m, (q, b));
-            let t = core.wrap.mul 0 (4I32, s);
-            pb (m, t, comp_cont);
-        let u = core.wrap.mul 0 (4I32, r);
+                let p = r * s;
+                fwd (m, (p + a, b));
+            pb (m, 4I32 * s, comp_cont);
+        let u = 4I32 * r;
         aug_ret (m, u, comp_tup_pb);
 
     con aug_pow_else (m: mem.M 0, unused: TupPb) =
-        let y = core.wrap.add 0 (4294967295I32, x);
-        aug_f (m, y, aug_pow_cont);
+        aug_f (m, 4294967295I32 + x, aug_pow_cont);
 
     con aug_pow_then (m: mem.M 0, unused: TupPb) =
         aug_ret (m, 1I32, zero_pb);
@@ -50,11 +49,9 @@ extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr («⊤:Nat; mem.Ptr («⊤
     con ret_cont (m: mem.M 0, r: I32, pb: Pb) =
         con pb_ret_cont (m: mem.M 0, prs: [I32, I32]) =
             let (pr_a, pr_b) = prs;
-            let a = core.wrap.mul 0 (10000I32, r);
-            let b = core.wrap.mul 0 (100I32, pr_a);
-            let c = core.wrap.add 0 (pr_b, b);
-            let d = core.wrap.add 0 (a, c);
-            fwd (m, d);
+            let a = 10000I32 * r;
+            let b = 100I32 * pr_a;
+            fwd (m, a + (pr_b + b));
         pb (m, 1I32, pb_ret_cont);
 
     aug_f (m, 3I32, ret_cont);

--- a/lit/clos/using_c_function.mim
+++ b/lit/clos/using_c_function.mim
@@ -12,6 +12,8 @@ plugin core;
 plugin cps;
 plugin mem;
 
+use core.ops.u.w;
+
 let pb_type = Cn [mem.M 0];
 
 extern con printInteger [m: mem.M 0, val: I32, return: Cn [mem.M 0]];
@@ -30,7 +32,7 @@ extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr («⊤:Nat; mem.Ptr («⊤
                 let (backward_pass_mem, backward_pass) = mem.load (m, lea_pb);  // <- begin backward pass
                 backward_pass (backward_pass_mem);
 
-            con yield (m: mem.M 0) = loop_head( m, core.wrap.add 0 (i, 1I32) );
+            con yield (m: mem.M 0) = loop_head( m, i + 1I32 );
 
             con body (m: mem.M 0) =
                 let (load_pb_mem, last_pb) = mem.load (m, lea_pb);
@@ -41,9 +43,8 @@ extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr («⊤:Nat; mem.Ptr («⊤
                 let store_pb_mem = mem.store (load_pb_mem, lea_pb, pb);  // << stack backward pass block
                 printInteger(store_pb_mem, i, yield);
 
-            let condition = core.icmp.ul (i, 19I32);
-            let target = (exit, body)#condition;
-            target ( m );
+            let condition = i < 19I32;
+            (exit, body)#condition ( m );
 
         loop_head ( store_pb, 0I32 ); // <-- start forward pass
 

--- a/lit/commute.mim
+++ b/lit/commute.mim
@@ -2,14 +2,16 @@
 plugin core;
 plugin refly;
 
-lam f1 (a b: Nat): Nat = core.nat.add (a, b);
+use core.ops.n;
+
+lam f1 (a b: Nat): Nat = a + b;
 lam f2 (ab: «2; Nat»): Nat =
     let b = ab#1₂; // this provokes b->gid() < a->gid()
     let a = ab#0₂;
-    core.nat.add (a, b);
+    a + b;
 
-lam g1 (a: Nat) (b: Nat): Nat = core.nat.add (a, b);
-lam g2 (a: Nat) (b: Nat): Nat = core.nat.add (a, b);
+lam g1 (a: Nat) (b: Nat): Nat = a + b;
+lam g2 (a: Nat) (b: Nat): Nat = a + b;
 
 let _ = refly.equiv.struc_eq (f1, f2);
 let _ = refly.equiv.alpha_eq (f1, f2);

--- a/lit/core/idx.mim
+++ b/lit/core/idx.mim
@@ -2,8 +2,8 @@
 
 plugin core;
 
-lam f0(s i: Nat): Idx s = core.idx s 0 i;
-lam f1(s i: Nat): Idx s = core.idx s 1 i;
+lam f0(s i: Nat): Idx s = core.idx 0 s i;
+lam f1(s i: Nat): Idx s = core.idx 1 s i;
 
 extern lam g0() = f0(42, 23);
 extern lam g1() = f1(42, 23);

--- a/lit/core/nat_div_mod.mim
+++ b/lit/core/nat_div_mod.mim
@@ -9,6 +9,8 @@ plugin core;
 plugin mem;
 import compile;
 
+use core.ops.n;
+
 // core.nat.div/rem fold the partial/degenerate cases at normalization time:
 //   a / 0 = 0,   a % 0 = a,   a % a = 0,   plus ordinary constant folding.
 // `x` is a runtime value, so `x / 0` and `x % x` exercise the symbolic rules;
@@ -18,11 +20,11 @@ import compile;
 // OPT-NOT: core.nat
 // OPT: (0, 7, 3, 1, 0)
 extern fun test_fold(x: Nat): [Nat, Nat, Nat, Nat, Nat] =
-    let a = core.nat.div (x, 0); // -> 0 (symbolic a / 0 = 0)
-    let b = core.nat.rem (7, 0); // -> 7 (a % 0 = a)
-    let c = core.nat.div (10, 3); // -> 3
-    let d = core.nat.rem (10, 3); // -> 1
-    let e = core.nat.rem (x, x); // -> 0 (symbolic a % a = 0)
+    let a = x / 0; // -> 0 (symbolic a / 0 = 0)
+    let b = 7 % 0; // -> 7 (a % 0 = a)
+    let c = 10 / 3; // -> 3
+    let d = 10 % 3; // -> 1
+    let e = x % x; // -> 0 (symbolic a % a = 0)
     return (a, b, c, d, e);
 
 // For a runtime (non-literal) divisor the axiom survives normalization and must
@@ -40,8 +42,7 @@ extern fun test_fold(x: Nat): [Nat, Nat, Nat, Nat, Nat] =
 // MOD: urem i64
 // MOD: select i1
 extern fun test_mod(m: mem.M 0, x y: Nat): [mem.M 0, Nat] =
-    let r = core.nat.rem (x, y);
-    return (m, r);
+    return (m, x % y);
 
 // DIV-LABEL: define{{.*}}@test_div
 // DIV: icmp eq i64
@@ -49,5 +50,4 @@ extern fun test_mod(m: mem.M 0, x y: Nat): [mem.M 0, Nat] =
 // DIV: udiv i64
 // DIV: select i1
 extern fun test_div(m: mem.M 0, x y: Nat): [mem.M 0, Nat] =
-    let q = core.nat.div (x, y);
-    return (m, q);
+    return (m, x / y);

--- a/lit/core/normalize_add.mim
+++ b/lit/core/normalize_add.mim
@@ -3,12 +3,14 @@
 
 plugin core;
 
+use core.ops.u.w;
+
 extern con add0 (i: I8, return: Cn I8) =
-    return (core.wrap.add 0 (i, 0I8));
+    return (i + 0I8);
 
 // CHECK-DAG: return_{{[0-9]+}} i_{{[0-9]+}}
 
 extern con add_lit (return: Cn I8) =
-    return (core.wrap.add 0 (6I8, 0I8));
+    return (6I8 + 0I8);
 
 // CHECK-DAG: return_{{[0-9]+}} 6I8

--- a/lit/core/pow.mim
+++ b/lit/core/pow.mim
@@ -6,18 +6,19 @@
 plugin core;
 plugin mem;
 
+use core.ops.u.w;
+
 fun pow(a b: I32): I32 =
     con pow_cont(v: I32) =
-        return (core.wrap.mul 0 (a, v));
+        return (a * v);
 
     con pow_then() =
         return 1I32;
 
     con pow_else() =
-        let b_1 = core.wrap.sub 0 (b, 1I32);
-        pow ((a, b_1), pow_cont);
+        pow ((a, b - 1I32), pow_cont);
 
-    let cmp = core.icmp.e (b, 0I32);
+    let cmp = b == 0I32;
     (pow_else, pow_then)#cmp ();
 
 extern fun main(m: mem.M 0, argc: I32, argv: mem.Ptr0 (mem.Ptr0 I8)): [mem.M 0, I32] =

--- a/lit/core/reassociate.mim
+++ b/lit/core/reassociate.mim
@@ -3,9 +3,11 @@
 
 plugin core;
 
+use core.ops.u.w;
+
 extern lam add(w: I32): I32 =
     let xy = 23I32;
     let z  = 42I32;
-    core.wrap.add 0 (xy, (core.wrap.add 0 (z, w)));
+    xy + (z + w);
 
 // CHECK-DAG: 65

--- a/lit/core/sub_bug.mim
+++ b/lit/core/sub_bug.mim
@@ -10,7 +10,7 @@ extern fun f(a: I8): «4; I8» =
             core.wrap.sub core.mode.nuw  (a, 1I8),
             core.wrap.sub core.mode.nsuw (a, 1I8));
 
-// CHECK-DAG: core.wrap.add i8 0 (255I8, a_{{[0-9]+}});
-// CHECK-DAG: core.wrap.sub i8 1 (a_{{[0-9]+}}, 1I8);
-// CHECK-DAG: core.wrap.sub i8 2 (a_{{[0-9]+}}, 1I8);
-// CHECK-DAG: core.wrap.sub i8 3 (a_{{[0-9]+}}, 1I8);
+// CHECK-DAG: core.wrap.add 0 i8 (255I8, a_{{[0-9]+}});
+// CHECK-DAG: core.wrap.sub 1 i8 (a_{{[0-9]+}}, 1I8);
+// CHECK-DAG: core.wrap.sub 2 i8 (a_{{[0-9]+}}, 1I8);
+// CHECK-DAG: core.wrap.sub 3 i8 (a_{{[0-9]+}}, 1I8);

--- a/lit/cps/cps2ds_dep_pack_dyn.mim
+++ b/lit/cps/cps2ds_dep_pack_dyn.mim
@@ -13,7 +13,7 @@ con f (n: Nat, return: Cn «n; Nat») = return ‹i: n; core.bitcast Nat i›;
 extern fun main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0)): [mem.M 0, I32] =
     let n  = core.bitcast Nat argc;
     let xs = cps.cps2ds_dep U f n;
-    return (m, core.bitcast I32 (xs#(core.idx n 0 0)));
+    return (m, core.bitcast I32 (xs#(core.idx 0 n 0)));
 
 // CHECK: extern fun main
 // CHECK: return

--- a/lit/cps/ds2cps_ax_cps2ds_dependent.mim
+++ b/lit/cps/ds2cps_ax_cps2ds_dependent.mim
@@ -7,7 +7,7 @@ plugin mem;
 
 lam U (n: Nat): * = Idx n;
 
-con f (n: Nat, return: Cn (Idx n)) = return (core.idx n 0 42);
+con f (n: Nat, return: Cn (Idx n)) = return (core.idx 0 n 42);
 
 extern fun main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0)): [mem.M 0, I32] =
     let c = cps.cps2ds_dep U f i32;

--- a/lit/cps/ds2cps_ax_cps2ds_twice_diff.mim
+++ b/lit/cps/ds2cps_ax_cps2ds_twice_diff.mim
@@ -8,12 +8,10 @@ plugin mem;
 use core.ops.u.w;
 
 fun f(a: I32): I32 =
-    let b = 2I32 + a;
-    return b;
+    return (2I32 + a);
 
 fun f2(a: I32): I32 =
-    let b = 30I32 + a;
-    return b;
+    return (30I32 + a);
 
 extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), return: Cn [mem.M 0, I32]) =
     return (m, cps.cps2ds f2 (cps.cps2ds f 10I32));

--- a/lit/cps/ds2cps_ax_cps2ds_twice_diff.mim
+++ b/lit/cps/ds2cps_ax_cps2ds_twice_diff.mim
@@ -5,19 +5,17 @@ plugin core;
 plugin cps;
 plugin mem;
 
+use core.ops.u.w;
+
 fun f(a: I32): I32 =
-    let b = core.wrap.add 0 (2I32, a);
+    let b = 2I32 + a;
     return b;
 
 fun f2(a: I32): I32 =
-    let b = core.wrap.add 0 (30I32, a);
+    let b = 30I32 + a;
     return b;
 
 extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), return: Cn [mem.M 0, I32]) =
-    let g = cps.cps2ds f;
-    let c1 = g 10I32;
-    let h = cps.cps2ds f2;
-    let c2 = h (c1);
-    return (m, c2);
+    return (m, cps.cps2ds f2 (cps.cps2ds f 10I32));
 
 // CHECK-DAG: return{{.*}}42

--- a/lit/cps/ds2cps_mixed2.mim
+++ b/lit/cps/ds2cps_mixed2.mim
@@ -7,16 +7,16 @@ plugin core;
 plugin cps;
 plugin mem;
 
+use core.ops.u.w;
 
-lam f (a: I32): I32 = core.wrap.add 0 (2I32, a);
+
+lam f (a: I32): I32 = 2I32 + a;
 
 con h (m: mem.M 0, a: I32, return: Cn [mem.M 0, I32]) =
-    let c = f a;
-    return (m, c);
+    return (m, f a);
 
 con g (m: mem.M 0, a: I32, return: Cn [mem.M 0, I32]) =
-    let b = core.wrap.add 0 (3I32, a);
-    h (m, b, return);
+    h (m, 3I32 + a, return);
 
 extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), return: Cn [mem.M 0, I32]) =
     g (m, 40I32, return);

--- a/lit/cps/ds2cps_mixed_tuple.mim
+++ b/lit/cps/ds2cps_mixed_tuple.mim
@@ -7,12 +7,14 @@ plugin core;
 plugin cps;
 plugin mem;
 
+use core.ops.u.w;
+
 lam f (a: I32): [I32, I32] =
-    (core.wrap.add 0 (2I32, a), core.wrap.add i32 (3I32, a));
+    (2I32 + a, core.wrap.add i32 (3I32, a));
 
 con h (m: mem.M 0, a: I32, return: Cn [mem.M 0, I32]) =
     let c = f a;
-    return (m, core.wrap.add 0 (c#ff, c#tt));
+    return (m, c#ff + c#tt);
 
 extern fun main(m: mem.M 0, argc: I32, argv: mem.Ptr0 (mem.Ptr0 I8)): [mem.M 0, I32] =
     h (m, 40I32, return);

--- a/lit/cps/ds_dependent.mim
+++ b/lit/cps/ds_dependent.mim
@@ -6,7 +6,7 @@ plugin cps;
 plugin mem;
 
 lam U (n: Nat): * = Idx n;
-lam f (n: Nat): Idx n = core.idx n 0 42;
+lam f (n: Nat): Idx n = core.idx 0 n 42;
 
 extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), return: Cn [mem.M 0, I32]) =
     let n = i32;

--- a/lit/cps/mut_dom_bug.mim
+++ b/lit/cps/mut_dom_bug.mim
@@ -2,14 +2,16 @@
 plugin core;
 plugin mem;
 
+use core.ops.u.w;
+
 lam ForBody (n: Nat) = [mem.M 0, Idx n] → [mem.M 0];
 
 lam For {n: Nat} (start _end: Idx n) (m: mem.M 0) (it: ForBody n): mem.M 0 =
     lam loop (m: mem.M 0, i: Idx n) @(core.pe.is_closed i): [mem.M 0, Idx n] =
         let m = it (m, i);
 
-        let j   = core.wrap.add 0 (i, core.idx 0 n 1);
-        let cmp = core.icmp.ul    (i, _end);
+        let j   = i + core.idx 0 n 1;
+        let cmp = i < _end;
         ((m, j), loop (m, j))#cmp;
 
     let (m, _) = loop (m, start);

--- a/lit/cps/mut_dom_bug.mim
+++ b/lit/cps/mut_dom_bug.mim
@@ -8,7 +8,7 @@ lam For {n: Nat} (start _end: Idx n) (m: mem.M 0) (it: ForBody n): mem.M 0 =
     lam loop (m: mem.M 0, i: Idx n) @(core.pe.is_closed i): [mem.M 0, Idx n] =
         let m = it (m, i);
 
-        let j   = core.wrap.add 0 (i, core.idx n 0 1);
+        let j   = core.wrap.add 0 (i, core.idx 0 n 1);
         let cmp = core.icmp.ul    (i, _end);
         ((m, j), loop (m, j))#cmp;
 

--- a/lit/docs/count.mim
+++ b/lit/docs/count.mim
@@ -1,17 +1,17 @@
 // RUN: %mim -p ll %s
 plugin core;
 
+use core.ops.u.w;
+
 extern fun count(n: I32): I32 =
     loop (0I32, 0I32)
     where
         con loop (i acc: I32) =
-            let cond = core.icmp.ul (i, n);
+            let cond = i < n;
             core.select (cond, body, exit) ()
             where
                 con body() =
-                    let next = core.wrap.add 0 (i, 1I32);
-                    let sum  = core.wrap.add 0 (acc, i);
-                    loop (next, sum);
+                    loop (i + 1I32, acc + i);
                 con exit() = return acc;
             end;
     end;

--- a/lit/docs/iter.mim
+++ b/lit/docs/iter.mim
@@ -2,18 +2,20 @@
 plugin core;
 plugin refly;
 
+use core.ops.n;
+
 extern lam iter {T: *} (f: T → T) (n: Nat, x: T)@(core.pe.is_closed n): T =
-    let cond = core.ncmp.le (n, 0);
+    let cond = n <= 0;
     (core.select (cond, cons, alt)) () where
         lam cons(): T =
             x;
         lam alt(): T =
-            let m = core.nat.sub (n, 1);
+            let m = n - 1;
             let y = f x;
             iter @T f (m, y);
     end;
 
-lam succ (x: Nat): Nat = core.nat.add (x, 1);
+lam succ (x: Nat): Nat = x + 1;
 lam add  (x: Nat) (y: Nat): Nat = iter succ (x, y);
 lam mul  (x: Nat) (y: Nat): Nat = iter (add x) (y, 0);
 lam pow  (x: Nat) (y: Nat): Nat = iter (mul x) (y, 1);

--- a/lit/fib.mim
+++ b/lit/fib.mim
@@ -6,16 +6,18 @@
 plugin core;
 plugin mem;
 
+use core.ops.n;
+
 con seq {A: *} (n: Nat) (body: [Cn A] → Cn A) (exit: Cn A) (acc: A)@tt =
     head(0, acc)
     where
         con head (i: Nat, acc: A)@core.pe.is_closed n =
-            let cond = core.ncmp.l (i, n);
+            let cond = i < n;
             (f, t)#cond ()
             where
                 con t() = body continue acc
                 where
-                    con continue(acc: A) = head ((core.nat.add (i, 1)), acc);
+                    con continue(acc: A) = head ((i + 1), acc);
                 end
                 con f() = exit acc;
             end;
@@ -24,14 +26,14 @@ con seq {A: *} (n: Nat) (body: [Cn A] → Cn A) (exit: Cn A) (acc: A)@tt =
 extern fun fib(n: Nat): Nat =
     seq n body exit (0, 1)
     where
-        con body (yield: Cn [Nat, Nat]) (a b: Nat) = yield (b, core.nat.add (a, b));
+        con body (yield: Cn [Nat, Nat]) (a b: Nat) = yield (b, a + b);
         con exit (a _: Nat) = return a;
     end
 
 extern fun main(argc: I32, argv: mem.Ptr0 (mem.Ptr0 I8)): I32 =
     seq 12 body exit (0, 1)
     where
-        con body (yield: Cn [Nat, Nat]) (a b: Nat) = yield (b, core.nat.add (a, b));
+        con body (yield: Cn [Nat, Nat]) (a b: Nat) = yield (b, a + b);
         con exit (a _: Nat) = return (core.bitcast I32 a);
     end;
 

--- a/lit/fun.mim
+++ b/lit/fun.mim
@@ -2,17 +2,19 @@
 plugin core;
 plugin mem;
 
+use core.ops.u.w;
+
 lam Ptr(T: *): * = mem.Ptr (T, 0);
 
 let _ = 23;
 
-fun foo(m: mem.M 0, x: I32)@(core.icmp.e (x, 23I32)): [mem.M 0, I32] =
-    return (m, core.wrap.add 0 (x, 1I32));
+fun foo(m: mem.M 0, x: I32)@(x == 23I32): [mem.M 0, I32] =
+    return (m, x + 1I32);
 
 extern fun main(m: mem.M 0, argc: I32, argv: Ptr (Ptr I8)): [mem.M 0, I32] =
     ret (m, x) = foo $ (m, 23I32);
     ret (m, y) = foo $ (m, 23I32);
-    return (m, core.wrap.add 0 (x, y));
+    return (m, x + y);
 
 lam f1(T: *) ((x y: T), return: T → ⊥): ⊥ = return x;
 con f2(T: *) ((x y: T), return: Cn T)     = return x;

--- a/lit/gpu/array_kernel.mim
+++ b/lit/gpu/array_kernel.mim
@@ -5,12 +5,14 @@ plugin core;
 plugin gpu;
 plugin mem;
 
+use core.ops.u.w;
+
 con kernel (m1: gpu.GlobalM, m3: gpu.SharedM, m4: gpu.ConstM, m5: gpu.LocalM,
             group_id item_id: Idx 4, (), data: gpu.GlobalPtr «4; I32»,
             return: Cn [gpu.GlobalM, gpu.SharedM, gpu.ConstM, gpu.LocalM]) =
     let el = mem.lea (data, item_id);
     let val = core.bitcast I32 item_id;
-    let val = core.wrap.add 0 (val, 42I32);
+    let val = val + 42I32;
     let m1 = mem.store (m1, el, val);
     return (m1, m3, m4, m5);
 
@@ -39,9 +41,7 @@ extern fun main (m0: mem.M 0, argc: I32, argv: mem.Ptr («⊤:Nat; mem.Ptr («�
 
     let m0 = gpu.deinit (m0, m1, m4);
 
-    let idx = core.bitcast (Idx 4) (core.wrap.sub 0 (argc, 1I32));
-    let val_arr = mem.lea (arr, idx);
-    let (m0, val) = mem.load (m0, val_arr);
+    let (m0, val) = mem.load (m0, mem.lea (arr, core.bitcast (Idx 4) (argc - 1I32)));
     let m0 = mem.free (m0, arr);
 
     return (m0, val);

--- a/lit/gpu/manual_sync_kernel.mim
+++ b/lit/gpu/manual_sync_kernel.mim
@@ -5,6 +5,8 @@ plugin core;
 plugin gpu;
 plugin mem;
 
+use core.ops.u.w;
+
 con kernel (m1: gpu.GlobalM, m3: gpu.SharedM, m4: gpu.ConstM, m5: gpu.LocalM,
             group_id item_id: Idx 4, (), data: gpu.GlobalPtr I32,
             return: Cn [gpu.GlobalM, gpu.SharedM, gpu.ConstM, gpu.LocalM]) =
@@ -13,10 +15,8 @@ con kernel (m1: gpu.GlobalM, m3: gpu.SharedM, m4: gpu.ConstM, m5: gpu.LocalM,
     let val = core.bitcast I32 item_id;
     let m3 = mem.store (m3, store_loc, val);
     let (m1, m3) = gpu.sync_work_items (m1, m3);
-    let load_idx = core.wrap.sub 0 (3₄, item_id);
-    let load_loc = mem.lea (shared_ptr, load_idx);
-    let (m3, load_val) = mem.load (m3, load_loc);
-    let cond = core.icmp.e (item_id, 1₄);
+    let (m3, load_val) = mem.load (m3, mem.lea (shared_ptr, 3₄ - item_id));
+    let cond = item_id == 1₄;
     (return, store)#cond (m1, m3, m4, m5)
     where
         lam store (m1: gpu.GlobalM, m3: gpu.SharedM, m4: gpu.ConstM, m5: gpu.LocalM) =

--- a/lit/gpu/scope_sync_kernel.mim
+++ b/lit/gpu/scope_sync_kernel.mim
@@ -5,6 +5,8 @@ plugin core;
 plugin gpu;
 plugin mem;
 
+use core.ops.u.w;
+
 con kernel (m1: gpu.GlobalM, m3: gpu.SharedM, m4: gpu.ConstM, m5: gpu.LocalM,
             group_id item_id: Idx 4, (), data: gpu.GlobalPtr I32,
             return: Cn [gpu.GlobalM, gpu.SharedM, gpu.ConstM, gpu.LocalM]) =
@@ -22,16 +24,14 @@ con kernel (m1: gpu.GlobalM, m3: gpu.SharedM, m4: gpu.ConstM, m5: gpu.LocalM,
     let (m1, m3) = gpu.synced_scope (m1, m3, scope)
     where
         lam scope (m1: gpu.GlobalM, m3: gpu.SharedM) =
-            let load_idx = core.wrap.sub 0 (3₄, item_id);
-            let load_loc = mem.lea (shared_ptr, load_idx);
-            let (m3, load_val) = mem.load (m3, load_loc);
-            let cond = core.icmp.e (item_id, 1₄);
+            let (m3, load_val) = mem.load (m3, mem.lea (shared_ptr, 3₄ - item_id));
+            let cond = item_id == 1₄;
             let m1 = mem.store (m1, local_data, load_val);
             (m1, m3);
     end;
     let (m1, val) = mem.load (m1, local_data);
     let m1 = mem.free (m1, local_data);
-    let cond = core.icmp.e (item_id, 1₄);
+    let cond = item_id == 1₄;
     (return, store)#cond (m1, m3, m4, m5)
     where
         lam store (m1: gpu.GlobalM, m3: gpu.SharedM, m4: gpu.ConstM, m5: gpu.LocalM) =

--- a/lit/ll_rt_wrapper.mim
+++ b/lit/ll_rt_wrapper.mim
@@ -28,6 +28,8 @@ plugin cps;
 plugin clos;
 plugin mem;
 
+use core.ops.u.w;
+
 let pb_type = Cn [mem.M 0];
 
 extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr («⊤:Nat; mem.Ptr («⊤:Nat; I8», 0)», 0), return: Cn [mem.M 0, I32]) =
@@ -43,7 +45,7 @@ extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr («⊤:Nat; mem.Ptr («⊤
             let (backward_pass_mem, backward_pass) = mem.load (m, lea_pb); // <- begin backward pass
             backward_pass (backward_pass_mem);
 
-        con yield (m: mem.M 0) = loop_head (m, core.wrap.add 0 (i, 1I32));
+        con yield (m: mem.M 0) = loop_head (m, i + 1I32);
 
         con body (m: mem.M 0) =
             let (load_pb_mem, last_pb) = mem.load (m, lea_pb);
@@ -52,8 +54,7 @@ extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr («⊤:Nat; mem.Ptr («⊤
             let store_pb_mem = mem.store (load_pb_mem, lea_pb, pb); // << stack backward pass block
             yield (store_pb_mem);
 
-        let condition = core.icmp.ul (i, 19I32);
-        let target = (exit, body)#condition;
-        target (m);
+        let condition = i < 19I32;
+        (exit, body)#condition (m);
 
     loop_head (store_pb, 0I32); // <-- start forward pass

--- a/lit/main_loop.mim
+++ b/lit/main_loop.mim
@@ -7,16 +7,18 @@
 plugin core;
 plugin mem;
 
+use core.ops.u.w;
+
 extern fun main(m: mem.M 0, argc: I32, argv: mem.Ptr0 (mem.Ptr0 I8)): [mem.M 0, I32] =
     loop (m, 0I32, 0I32)
     where
         con loop(m: mem.M 0, i acc: I32) =
-            let cond = core.icmp.ul (i, argc);
+            let cond = i < argc;
             (exit, body)#cond m
             where
                 con body m: mem.M 0 =
-                    let inc = core.wrap.add 0 (1I32, i);
-                    let acc = core.wrap.add 0 (i, acc);
+                    let inc = 1I32 + i;
+                    let acc = i + acc;
                     loop (m, inc, acc);
                 con exit(m: mem.M 0) = return (m, acc);
             end

--- a/lit/math/exp.mim
+++ b/lit/math/exp.mim
@@ -7,10 +7,9 @@ plugin math;
 plugin core;
 plugin mem;
 
+use math.ops.none;
+
 extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), return: Cn [mem.M 0, I32]) =
     let s = math.conv.u2f math.f32 argc;
-    let x = math.exp.log2 0 (math.exp.exp 0 s);
-    let y = math.exp.log 0 (math.exp.exp2 0 s);
-    let z = math.arith.add 0 (x, y);
-    let r = math.conv.f2u i32 (math.arith.mul 0 (math.conv.f2f math.f64 z, 10.0:math.F64));
-    return (m, r);
+    let z = math.exp.log2 0 (math.exp.exp 0 s) + math.exp.log 0 (math.exp.exp2 0 s);
+    return (m, math.conv.f2u i32 (math.conv.f2f math.f64 z * 10.0:math.F64));

--- a/lit/math/fold.mim
+++ b/lit/math/fold.mim
@@ -4,6 +4,8 @@ plugin math;
 plugin core;
 plugin refly;
 
+use math.ops.none;
+
 let f32_1  = math.conv.u2f math.f32 1I32;
 let f32_2  = math.conv.u2f math.f32 2I32;
 let f64_2  = math.conv.u2f math.f64 2I32;
@@ -15,12 +17,12 @@ let f64_42 = math.conv.u2f math.f64 42I32;
 let f64_m1 = math.conv.s2f math.f64 255I8;
 let f64_m15 = math.conv.s2f math.f64 241I8;
 
-let _ = refly.equiv.struc_eq (math.conv.f2u i32 (math.arith.add 0 (f32_1, f32_2)), 3I32);
-let _ = refly.equiv.struc_eq (math.conv.f2u i32 (math.arith.mul 0 (f64_3, f64_2)), 6I32);
+let _ = refly.equiv.struc_eq (math.conv.f2u i32 (f32_1 + f32_2), 3I32);
+let _ = refly.equiv.struc_eq (math.conv.f2u i32 (f64_3 * f64_2), 6I32);
 let _ = refly.equiv.struc_eq (math.conv.f2u i32 (math.pow 0 (f64_2, f64_3)), 8I32);
 let _ = refly.equiv.struc_eq (math.conv.f2u i32 (math.abs 0 f64_m1), 1I32);
-let _ = refly.equiv.struc_eq (math.conv.f2s i8 (math.round.t 0 (math.arith.div 0 (f64_m15, f64_4))), 253I8);
+let _ = refly.equiv.struc_eq (math.conv.f2s i8 (math.round.t 0 (f64_m15 / f64_4)), 253I8);
 let _ = refly.equiv.struc_eq (math.conv.f2u i32 f64_42, 42I32);
 let _ = refly.equiv.struc_eq (math.conv.f2s i8 f64_m1, 255I8);
 let _ = refly.equiv.struc_eq (math.conv.f2u i32 (math.conv.f2f math.f32 f64_42), 42I32);
-let _ = refly.equiv.struc_eq (math.conv.f2u i32 (math.arith.div 0 (math.conv.u2f math.f64 171I32, f64_4)), 42I32);
+let _ = refly.equiv.struc_eq (math.conv.f2u i32 (math.conv.u2f math.f64 171I32 / f64_4), 42I32);

--- a/lit/math/normalize_fastmath.mim
+++ b/lit/math/normalize_fastmath.mim
@@ -3,7 +3,7 @@
 plugin math;
 
 // CHECK-DAG: extern fun foo (f_{{[0-9]+}}: math.F (23, 8)): math.F (23, 8) =
-// CHECK-DAG: let _[[FOO_VAL:[0-9]+]]: {{.*}} = math.arith.sub (23, 8) 127 (0:(math.F (23, 8)), f_{{[0-9]+}})
+// CHECK-DAG: let _[[FOO_VAL:[0-9]+]]: {{.*}} = math.arith.sub 127 (23, 8) (0:(math.F (23, 8)), f_{{[0-9]+}})
 // CHECK-DAG: return_{{[0-9_]+}} _[[FOO_VAL]]
 extern con foo(f: math.F32, return: Cn math.F32) = return (math.minus 127 f);
 

--- a/lit/math/normalize_fastmath.mim
+++ b/lit/math/normalize_fastmath.mim
@@ -2,27 +2,29 @@
 
 plugin math;
 
+use math.ops.fast;
+
 // CHECK-DAG: extern fun foo (f_{{[0-9]+}}: math.F (23, 8)): math.F (23, 8) =
 // CHECK-DAG: let _[[FOO_VAL:[0-9]+]]: {{.*}} = math.arith.sub 127 (23, 8) (0:(math.F (23, 8)), f_{{[0-9]+}})
 // CHECK-DAG: return_{{[0-9_]+}} _[[FOO_VAL]]
-extern con foo(f: math.F32, return: Cn math.F32) = return (math.minus 127 f);
+extern con foo(f: math.F32, return: Cn math.F32) = return (math.minus math.mode.fast f);
 
 // CHECK-DAG: extern fun sub0 (f_{{[0-9]+}}: math.F (23, 8)): math.F (23, 8) =
 // CHECK-DAG: return_{{[0-9_]+}} f_{{[0-9]+}}
-extern con sub0(f: math.F32, return: Cn math.F32) = return (math.arith.sub 127 (f, 0:(math.F32)));
+extern con sub0(f: math.F32, return: Cn math.F32) = return (f - 0:(math.F32));
 
 // CHECK-DAG: extern fun add0 (f_{{[0-9]+}}: math.F (23, 8)): math.F (23, 8) =
 // CHECK-DAG: return_{{[0-9_]+}} f_{{[0-9]+}}
-extern con add0(f: math.F32, return: Cn math.F32) = return (math.arith.add 127 (f, 0:(math.F32)));
+extern con add0(f: math.F32, return: Cn math.F32) = return (f + 0:(math.F32));
 
 // CHECK-DAG: extern fun add0f (f_{{[0-9]+}}: math.F (23, 8)): math.F (23, 8) =
 // CHECK-DAG: return_{{[0-9_]+}} f_{{[0-9]+}}
-extern con add0f(f: math.F32, return: Cn math.F32) = return (math.arith.add 127 (0:(math.F32), f));
+extern con add0f(f: math.F32, return: Cn math.F32) = return (0:(math.F32) + f);
 
 // CHECK-DAG: extern fun mul0 (_: math.F (23, 8)): math.F (23, 8) =
 // CHECK-DAG: return_{{[0-9_]+}} 0:(math.F (23, 8))
-extern con mul0(f: math.F32, return: Cn math.F32) = return (math.arith.mul 127 (f, 0:(math.F32)));
+extern con mul0(f: math.F32, return: Cn math.F32) = return (f * 0:(math.F32));
 
 // CHECK-DAG: extern fun mul0f (_: math.F (23, 8)): math.F (23, 8) =
 // CHECK-DAG: return_{{[0-9_]+}} 0:(math.F (23, 8))
-extern con mul0f(f: math.F32, return: Cn math.F32) = return (math.arith.mul 127 (0:(math.F32), f));
+extern con mul0f(f: math.F32, return: Cn math.F32) = return (0:(math.F32) * f);

--- a/lit/math/tri.mim
+++ b/lit/math/tri.mim
@@ -7,11 +7,9 @@ plugin math;
 plugin mem;
 plugin core;
 
+use math.ops.none;
+
 extern con main (m: mem.M 0, argc: I32, argv: mem.Ptr (mem.Ptr (I8, 0), 0), return: Cn [mem.M 0, I32]) =
-    let s   = math.conv.u2f math.f32 argc;
-    let d   = math.conv.u2f math.f64 argc;
-    let x   = math.conv.f2f math.f64 (math.tri.sin 0 s);
-    let y   = math.tri.atanh 0 (math.arith.div 0 (d, 10.0:math.F64));
-    let z   = math.pow 0 (x, y);
-    let res = math.arith.mul 0 (z, 100.0:math.F64);
-    return (m, math.conv.f2u i32 res);
+    let x = math.conv.f2f math.f64 (math.tri.sin 0 (math.conv.u2f math.f32 argc));
+    let y = math.tri.atanh 0 (math.conv.u2f math.f64 argc / 10.0:math.F64);
+    return (m, math.conv.f2u i32 (math.pow 0 (x, y) * 100.0:math.F64));

--- a/lit/mem/arg_style.mim
+++ b/lit/mem/arg_style.mim
@@ -6,6 +6,8 @@
 plugin core;
 plugin mem;
 
+use core.ops.u.w;
+
 let Tas = (I32, 0);
 
 // We want the functions to be extern.
@@ -20,19 +22,19 @@ extern con f2 ((m: mem.M 0, a: I32), return: Cn [mem.M 0, I32]) =
     return (m, a);
 
 extern con g1 (m: mem.M 0, a b: I32, return: Cn [mem.M 0, I32]) =
-    let c = core.wrap.add 0 (a, b);
+    let c = a + b;
     return (m, c);
 
 extern con g2 ((m: mem.M 0, a b: I32), return: Cn [mem.M 0, I32]) =
-    let c = core.wrap.add 0 (a, b);
+    let c = a + b;
     return (m, c);
 
 extern con g3 ((m: mem.M 0, (a b: I32)), return: Cn [mem.M 0, I32]) =
-    let c = core.wrap.add 0 (a, b);
+    let c = a + b;
     return (m, c);
 
 extern con g4 (m: mem.M 0, (a b: I32), return: Cn [mem.M 0, I32]) =
-    let c = core.wrap.add 0 (a, b);
+    let c = a + b;
     return (m, c);
 
 extern con h1 (m: mem.M 0, a: I32, x: mem.Ptr (I32, 0), return: Cn [mem.M 0, I32]) =

--- a/lit/mem/largeArr.mim
+++ b/lit/mem/largeArr.mim
@@ -8,6 +8,6 @@ let size = 100000000;
 
 extern con main(m: mem.M 0, argc: I32, argv: mem.Ptr («⊤:Nat; mem.Ptr («⊤:Nat; I8», 0)», 0), return: Cn [mem.M 0, I32]) =
     let (m, arr) = mem.alloc («size; I32», 0) m;
-    let lea = mem.lea (arr, core.idx size 0 0);
+    let lea = mem.lea (arr, core.idx 0 size 0);
     let (m, val) = mem.load (m, lea);
     return (m, 1I32);

--- a/lit/mem/seo/click.mim
+++ b/lit/mem/seo/click.mim
@@ -5,6 +5,8 @@ plugin compile;
 plugin ll;
 plugin mem;
 
+use core.ops.n;
+
 extern fun dont_know[]: Bool;
 extern fun read[]: Nat;
 
@@ -17,14 +19,14 @@ extern fun foo(x: Nat): Nat =
             ret cond = dont_know $ ();
             (exit, body)#cond () where
                 con body() =
-                    let cond = core.ncmp.ne (y, z);
+                    let cond = y != z;
                     (f1, t1)#cond ()
                     where
                         con f1() = n1 x;
                         con t1() = n1 2;
                         con n1(x: Nat) =
-                            let x    = core.nat.sub (2, x);
-                            let cond = core.ncmp.ne (x, 1);
+                            let x    = 2 - x;
+                            let cond = x != 1;
                             (f2, t2)#cond ()
                             where
                                 con f2() = n2 y;

--- a/lit/mem/seo/dont_prop_old.mim
+++ b/lit/mem/seo/dont_prop_old.mim
@@ -17,6 +17,8 @@ plugin compile;
 plugin ll;
 plugin mem;
 
+use core.ops.n;
+
 extern fun dont_know[]: Bool;
 
 extern fun f(x: Nat): Nat =
@@ -25,7 +27,7 @@ extern fun f(x: Nat): Nat =
             ret cond = dont_know $ ();
             (exit, body)#cond () where
                 con body() =
-                    let cond       = core.ncmp.e (x, 23);
+                    let cond       = x == 23;
                     (false, true)#cond ()
                     where
                         con true () =
@@ -34,7 +36,7 @@ extern fun f(x: Nat): Nat =
                         con false() =
                             next (i, 4);
                         con next (i j: Nat) as cxt =
-                            let i = core.nat.add (i, 1);
+                            let i = i + 1;
                             head i;
                     end;
 

--- a/lit/mem/seo/gvn.mim
+++ b/lit/mem/seo/gvn.mim
@@ -4,6 +4,8 @@ plugin compile;
 plugin ll;
 plugin mem;
 
+use core.ops.n;
+
 extern fun dont_know[]: Bool;
 
 extern fun f(x: Nat): Nat =
@@ -12,23 +14,23 @@ extern fun f(x: Nat): Nat =
             ret cond = dont_know $ ();
             (exit, body)#cond () where
                 con body() =
-                    let cond       = core.ncmp.le (i, j);
+                    let cond       = i <= j;
                     (false, true)#cond ()
                     where
                         con false () =
-                            let i = core.nat.add (i, 2); // unreachable due to GVN
-                            let j = core.nat.add (j, 1);
+                            let i = i + 2; // unreachable due to GVN
+                            let j = j + 1;
                             next (i, j);
 
                         con true() =
-                            let i = core.nat.add (i, 1);
-                            let j = core.nat.add (j, 1);
+                            let i = i + 1;
+                            let j = j + 1;
                             next (i, j);
                         con next (i j: Nat) as ij = head ij;
                     end;
 
                 con exit() =
-                    return (core.nat.add (i, j));
+                    return (i + j);
             end
     end;
 

--- a/lit/mem/seo/higher-order.mim
+++ b/lit/mem/seo/higher-order.mim
@@ -5,18 +5,20 @@ plugin core;
 plugin compile;
 plugin ll;
 
+use core.ops.n;
+
 extern fun dont_know[m: mem.M 0]: [mem.M 0, Bool];
 extern fun take_addr[m: mem.M 0, mem.Ptr0 Nat]: [mem.M 0];
 
 let H = Fn [mem.M 0, Nat] →  [mem.M 0, Nat];
 
 fun h (m: mem.M 0, n: Nat): [mem.M 0, Nat] =
-    return (m, core.nat.mul (n, n));
+    return (m, n * n);
 
 fun g (m: mem.M 0, h: H): [mem.M 0, Nat] =
     ret (m, res1) = h $ (m, 23);
     ret (m, res2) = h $ (m, 23);
-    return (m, core.nat.add (res1, res2));
+    return (m, res1 + res2);
 
 extern fun f (m: mem.M 0, x: Nat): [mem.M 0, Nat] =
     ret (m, ph) = mem.slot (H,   0) $ m;
@@ -32,8 +34,8 @@ extern fun f (m: mem.M 0, x: Nat): [mem.M 0, Nat] =
                     let (m, vr) = mem.load (m, pr);
                     ret (m, res1) = g $ (m, vh);
                     ret (m, res2) = g $ (m, vh);
-                    let add = core.nat.add (vr, res1);
-                    let add = core.nat.add (add, res2);
+                    let add = vr + res1;
+                    let add = add + res2;
                     let m = mem.store (m, pr, add);
                     head m;
 

--- a/lit/mem/seo/loop.mim
+++ b/lit/mem/seo/loop.mim
@@ -4,6 +4,8 @@ plugin compile;
 plugin ll;
 plugin mem;
 
+use core.ops.n;
+
 extern fun dont_know[]: Bool;
 
 extern fun f(x: Nat): Nat =
@@ -12,22 +14,22 @@ extern fun f(x: Nat): Nat =
             ret cond = dont_know $ ();
             (exit, body)#cond () where
                 con body() =
-                    let cond       = core.ncmp.e (c, 23);
+                    let cond       = c == 23;
                     (false, true)#cond ()
                     where
                         con true () =
                             next (c, x, 4);
 
                         con false() =
-                            let c = core.nat.add (c, 1);
-                            let x = core.nat.add (x, 1);
+                            let c = c + 1;
+                            let x = x + 1;
                             next (c, x, t);
                         con next (c x t: Nat) as cxt = head cxt;
                     end;
 
                 con exit() =
-                    let r = core.nat.add (c, x);
-                    let s = core.nat.add (r, t);
+                    let r = c + x;
+                    let s = r + t;
                     return s;
             end
     end;

--- a/lit/mem/seo/phi-var-combis.mim
+++ b/lit/mem/seo/phi-var-combis.mim
@@ -20,6 +20,8 @@ plugin core;
 plugin compile;
 plugin ll;
 
+use core.ops.n;
+
 extern fun dont_know[m: mem.M 0]: [mem.M 0, Bool];
 extern fun take_addr[m: mem.M 0, mem.Ptr0 Nat]: [mem.M 0];
 
@@ -40,13 +42,13 @@ extern fun f (m: mem.M 0): [mem.M 0, Nat] =
                     let (m, va ) = mem.load (m, pa );
                     let (m, vb1) = mem.load (m, pb1);
                     let (m, vb2) = mem.load (m, pb2);
-                    let cond       = core.ncmp.e (vb1, vb2);
+                    let cond       = vb1 == vb2;
                     (ff1, tt1)#cond m
                     where
                         con tt1 (m: mem.M 0) =
-                            let va  = core.nat.add (va , 1);
-                            let vb1 = core.nat.add (vb1, 2);
-                            let vb2 = core.nat.add (vb2, 2);
+                            let va  = va + 1;
+                            let vb1 = vb1 + 2;
+                            let vb2 = vb2 + 2;
                             let m = mem.store (m, pa , va );
                             let m = mem.store (m, pb1, vb2);
                             let m = mem.store (m, pb2, vb1);
@@ -59,28 +61,28 @@ extern fun f (m: mem.M 0): [mem.M 0, Nat] =
                             n1 (m, a, b1, b2, c);
 
                         con n1 (m: mem.M 0, a b1 b2 c: Nat) =
-                            let cond = core.ncmp.e (b1, b2);
+                            let cond = b1 == b2;
                             (ff2, tt2)#cond m
                             where
                                 con tt2 (m: mem.M 0) =
-                                    let a  = core.nat.add (a , 1);
-                                    let b1 = core.nat.add (b1, 2);
-                                    let b2 = core.nat.add (b2, 2);
+                                    let a  = a + 1;
+                                    let b1 = b1 + 2;
+                                    let b2 = b2 + 2;
                                     n2 (m, a, b1, b2, c);
 
                                 con ff2 (m: mem.M 0) =
-                                    let b1 = core.nat.add (b1, 23);
-                                    let b2 = core.nat.add (b2, 42);
+                                    let b1 = b1 + 23;
+                                    let b2 = b2 + 42;
                                     n2 (m, a, b1, b2, c);
 
                                 con n2 (m: mem.M 0, a b2 b1 c: Nat) =
                                     let (m, vc) = mem.load (m, pc);
-                                    let cond      = core.ncmp.e (vc, c);
+                                    let cond      = vc == c;
                                     (ff3, tt3)#cond m
                                     where
                                         con tt3 (m: mem.M 0) =
-                                            let vc = core.nat.add (vc, 3);
-                                            let  c = core.nat.add ( c, 3);
+                                            let vc = vc + 3;
+                                            let  c = c + 3;
                                             let m = mem.store (m, pc, c);
                                             n3 (m, a, b2, b1, c);
 
@@ -101,13 +103,13 @@ extern fun f (m: mem.M 0): [mem.M 0, Nat] =
                     let (m, vb2) = mem.load (m, pb2);
                     let (m, vc ) = mem.load (m, pc );
                     let res        = va;
-                    let res        = core.nat.add (res, vb1);
-                    let res        = core.nat.add (res, vb2);
-                    let res        = core.nat.add (res, vc );
-                    let res        = core.nat.add (res,  a );
-                    let res        = core.nat.add (res,  b1);
-                    let res        = core.nat.add (res,  b2);
-                    let res        = core.nat.add (res,  c );
+                    let res        = res + vb1;
+                    let res        = res + vb2;
+                    let res        = res + vc;
+                    let res        = res + a;
+                    let res        = res + b1;
+                    let res        = res + b2;
+                    let res        = res + c;
                     return (m, res);
             end
     end;

--- a/lit/mem/seo/precise_ssa.mim
+++ b/lit/mem/seo/precise_ssa.mim
@@ -5,6 +5,8 @@ plugin mem;
 plugin compile;
 plugin ll;
 
+use core.ops.n;
+
 extern fun dont_know[m: mem.M 0]: [mem.M 0, Bool];
 
 extern fun use_address[m: mem.M 0, ptr: mem.Ptr (Nat, 0)]: [mem.M 0];
@@ -28,7 +30,7 @@ extern fun test(m: mem.M 0): [mem.M 0, Nat] =
                     let (m, x) = mem.load (m, px);
                     let (m, y) = mem.load (m, py);
 
-                    let eq = core.ncmp.e (x, y);
+                    let eq = x == y;
 
                     (false_branch, true_branch)#eq m where
 
@@ -37,10 +39,10 @@ extern fun test(m: mem.M 0): [mem.M 0, Nat] =
                         //     y++;
                         // }
                         con true_branch(m: mem.M 0) =
-                            let x1  = core.nat.add (x, 1);
+                            let x1  = x + 1;
                             let m = mem.store (m, px, x1);
 
-                            let y1  = core.nat.add (y, 1);
+                            let y1  = y + 1;
                             let m = mem.store (m, py, y1);
 
                             head m;

--- a/lit/mem/seo/ptr_indirect.mim
+++ b/lit/mem/seo/ptr_indirect.mim
@@ -5,6 +5,8 @@ plugin mem;
 plugin compile;
 plugin ll;
 
+use core.ops.n;
+
 extern fun dont_know[m: mem.M 0]: [mem.M 0, Bool];
 
 extern fun use_address[m: mem.M 0, ptr: mem.Ptr (Nat, 0)]: [mem.M 0];
@@ -28,7 +30,7 @@ extern fun test(m: mem.M 0): [mem.M 0, Nat] =
                     let (m, x) = mem.load (m, px);
                     let (m, y) = mem.load (m, py);
 
-                    let eq = core.ncmp.e (x, y);
+                    let eq = x == y;
 
                     (false_branch, true_branch)#eq m where
 
@@ -37,10 +39,10 @@ extern fun test(m: mem.M 0): [mem.M 0, Nat] =
                         //     y++;
                         // }
                         con true_branch(m: mem.M 0) =
-                            let x1  = core.nat.add (x, 1);
+                            let x1  = x + 1;
                             let m = mem.store (m, px, x1);
 
-                            let y1  = core.nat.add (y, 1);
+                            let y1  = y + 1;
                             let m = mem.store (m, py, y1);
 
                             head (m, px, py);

--- a/lit/mem/seo/scope.mim
+++ b/lit/mem/seo/scope.mim
@@ -3,6 +3,8 @@ plugin core;
 plugin compile;
 plugin mem;
 
+use core.ops.n;
+
 extern fun dont_know[]: Bool;
 
 // Two chained loops: the outer accumulator `acc_a` starts as ⊥ and is
@@ -20,8 +22,8 @@ extern fun f(x: Nat): Nat =
                         con head_b(j acc_b: Nat) =
                             ret cb = dont_know $ ();
                             (body_b, exit_b)#cb () where
-                                con body_b() = head_b (core.nat.add (j, 1), 7);
-                                con exit_b() = head_a (core.nat.add (i, 1), acc_b);
+                                con body_b() = head_b (j + 1, 7);
+                                con exit_b() = head_a (i + 1, acc_b);
                             end;
                     end;
 

--- a/lit/mem/seo/simple.mim
+++ b/lit/mem/seo/simple.mim
@@ -3,13 +3,15 @@ plugin core;
 plugin compile;
 plugin mem;
 
-lam f (x1 x2 x3: Nat)@ff: Nat = core.nat.add (x1, core.nat.add (x2, x3));
+use core.ops.n;
+
+lam f (x1 x2 x3: Nat)@ff: Nat = x1 + (x2 + x3);
 lam g (x y: Nat)@ff: Nat = y;
 
 extern lam lf(a: Nat): Nat =
-    core.nat.add (f (42, a, 23), f (42, a, 3));
+    f (42, a, 23) + f (42, a, 3);
 
-extern lam lg(a: Nat): Nat = core.nat.sub (g (23, 1), g (23, a));
+extern lam lg(a: Nat): Nat = g (23, 1) - g (23, a);
 
 extern lam _compile(): compile.Phase =
     compile.phases ff (

--- a/lit/mem/two_fun_mem.mim
+++ b/lit/mem/two_fun_mem.mim
@@ -8,6 +8,8 @@
 plugin core;
 plugin mem;
 
+use core.ops.u.w;
+
 let Tas = (I32, 0);
 
 con f(m: mem.M 0, p: mem.Ptr0 I32, return: Cn [mem.M 0, I32]) =
@@ -15,16 +17,16 @@ con f(m: mem.M 0, p: mem.Ptr0 I32, return: Cn [mem.M 0, I32]) =
     g1 (m, cont1)
     where
         con g1 (m: mem.M 0, return: Cn [mem.M 0, I32]) =
-            let b = core.wrap.add 0 (v, 1I32);
+            let b = v + 1I32;
             return (m, b);
         con cont1 (m: mem.M 0, a: I32) =
             g2 (m, cont2)
             where
                 con g2(m: mem.M 0, return: Cn [mem.M 0, I32]) =
-                    let c = core.wrap.add 0 (v, 2I32);
+                    let c = v + 2I32;
                     return (m, c);
                 con cont2 (m: mem.M 0, b: I32) =
-                    let c = core.wrap.add 0 (a, b);
+                    let c = a + b;
                     return (m, c);
             end;
     end;

--- a/lit/mem/two_fun_no_mem.mim
+++ b/lit/mem/two_fun_no_mem.mim
@@ -8,6 +8,8 @@
 plugin core;
 plugin mem;
 
+use core.ops.u.w;
+
 let Tas = (I32, 0);
 
 con f (m: mem.M 0, p: mem.Ptr (I32, 0), return: Cn [mem.M 0, I32]) =
@@ -15,17 +17,17 @@ con f (m: mem.M 0, p: mem.Ptr (I32, 0), return: Cn [mem.M 0, I32]) =
     g1 cont1
     where
         con g1 (return: Cn I32) =
-            let b = core.wrap.add 0 (v, 1I32);
+            let b = v + 1I32;
             return b;
 
         con cont1 (a: I32) =
             g2 cont2
             where
                 con g2 (return: Cn I32) =
-                    let c = core.wrap.add 0 (v, 2I32);
+                    let c = v + 2I32;
                     return c;
                 con cont2 (b: I32) =
-                    let c = core.wrap.add 0 (a, b);
+                    let c = a + b;
                     return (m, c);
             end;
     end;

--- a/lit/mem/two_fun_no_mem.mim
+++ b/lit/mem/two_fun_no_mem.mim
@@ -17,15 +17,13 @@ con f (m: mem.M 0, p: mem.Ptr (I32, 0), return: Cn [mem.M 0, I32]) =
     g1 cont1
     where
         con g1 (return: Cn I32) =
-            let b = v + 1I32;
-            return b;
+            return (v + 1I32);
 
         con cont1 (a: I32) =
             g2 cont2
             where
                 con g2 (return: Cn I32) =
-                    let c = v + 2I32;
-                    return c;
+                    return (v + 2I32);
                 con cont2 (b: I32) =
                     let c = a + b;
                     return (m, c);

--- a/lit/mod/local.mim
+++ b/lit/mod/local.mim
@@ -3,13 +3,15 @@
 
 plugin core;
 
+use core.ops.u.w;
+
 extern lam f(): I32 =
     import "lib.mim";
     mod m { pub let two = 2I32; }
     use m;
-    core.wrap.add 0 (lib.answer, two);
+    lib.answer + two;
 
-extern lam g(): I32 = core.wrap.add 0 (lib.answer, l.inner.deep) where
+extern lam g(): I32 = lib.answer + l.inner.deep where
     import "lib.mim";
     import "lib.mim" as l;
 end;

--- a/lit/mod/mod.mim
+++ b/lit/mod/mod.mim
@@ -5,6 +5,8 @@ import "lib.mim";
 import "lib.mim" as l2;
 import "sub/lib2.mim";
 
+use core.ops.u.w;
+
 mod foo {
     pub let bar = 1I32;
 
@@ -13,11 +15,11 @@ mod foo {
     }
 }
 
-extern lam f(): I32 = core.wrap.add 0 (foo.bar, foo.nested.baz);
-extern lam g(): I32 = core.wrap.add 0 (lib.answer, l2.inner.deep);
+extern lam f(): I32 = foo.bar + foo.nested.baz;
+extern lam g(): I32 = lib.answer + l2.inner.deep;
 extern lam h(): I32 = l2.inner.deeper.deepest;
-extern lam i(): I32 = core.wrap.add 0 (lib2.base, lib2.util.deep.leaf);
-extern lam j(): I32 = core.wrap.add 0 (lib2.total, lib2.util.scale);
+extern lam i(): I32 = lib2.base + lib2.util.deep.leaf;
+extern lam j(): I32 = lib2.total + lib2.util.scale;
 
 // A `/` in the directive stays a `/` when dumped - a native Windows `\` would not re-parse.
 // CHECK-DAG: import "{{.*}}/mod/sub/lib2.mim";

--- a/lit/nesting/paper_b.mim
+++ b/lit/nesting/paper_b.mim
@@ -3,8 +3,10 @@
 
 import core;
 
-lam add (a: Nat) (b: Nat) = core.nat.add (a, b);
-lam le (a: Nat) (b: Nat) = core.ncmp.le (a, b);
+use core.ops.n;
+
+lam add (a: Nat) (b: Nat) = a + b;
+lam le (a: Nat) (b: Nat) = a <= b;
 
 extern fun f (n: Nat): Nat =
     con hi (i: Nat) =

--- a/lit/nesting/paper_c.mim
+++ b/lit/nesting/paper_c.mim
@@ -3,8 +3,10 @@
 
 import core;
 
-lam add (a: Nat) (b: Nat) = core.nat.add (a, b);
-lam le (a: Nat) (b: Nat) = core.ncmp.le (a, b);
+use core.ops.n;
+
+lam add (a: Nat) (b: Nat) = a + b;
+lam le (a: Nat) (b: Nat) = a <= b;
 
 extern fun f (n: Nat): Nat =
     con hi (i: Nat) =

--- a/lit/ord/loop.mim
+++ b/lit/ord/loop.mim
@@ -23,7 +23,7 @@ uint64_t f(uint64_t x) {
         }
     }
 
-    return map[1];
+    return (map[1]);
 }
 */
 
@@ -31,6 +31,8 @@ plugin mem;
 plugin ord;
 plugin core;
 plugin option;
+
+use core.ops.u.w;
 
 let Key = (I32, core.icmp.ul @i32);
 let Map = ord.Map Key I64;
@@ -61,10 +63,10 @@ extern fun f(m: mem.M 0, x: I64): [mem.M 0, I64] =
 
                         con ff1 (m: mem.M 0) = n1 m;
                         con n1 (m: mem.M 0) =
-                            (ff2, tt2)#(core.icmp.e (i, j)) m where
+                            (ff2, tt2)#(i == j) m where
                                 con tt2 (m: mem.M 0) =
-                                    let i = core.wrap.add 0 (i, 1I64);
-                                    let j = core.wrap.add 0 (j, 1I64);
+                                    let i = i + 1I64;
+                                    let j = j + 1I64;
                                     n2 (m, i, j);
                                 con ff2 (m: mem.M 0) =
                                     ret m = take_addr $ (m, ptr);
@@ -76,9 +78,7 @@ extern fun f(m: mem.M 0, x: I64): [mem.M 0, I64] =
 
                 con exit(m: mem.M 0) =
                     let (m, map) = mem.load (m, ptr);
-                    let opt_v      = ord.get (map, 1I32);
-                    let val        = option.unwrap_unsafe opt_v;
-                    return (m, val);
+                    return (m, option.unwrap_unsafe (ord.get (map, 1I32)));
             end
     end;
 

--- a/lit/pow_pe.mim
+++ b/lit/pow_pe.mim
@@ -1,8 +1,10 @@
 // RUN: %mim -p opt %s -o -
 plugin core;
 
-lam pow(a b: Nat)@(core.pe.is_closed b): Nat =
-    (core.nat.mul (a, pow(a, core.nat.sub (b, 1))), 1)#(core.ncmp.e (b, 0));
+use core.ops.n;
 
-lam f(n: Nat, x: «core.nat.mul (n, core.nat.mul (n, n)); Nat»): [] = ();
+lam pow(a b: Nat)@(core.pe.is_closed b): Nat =
+    (a * pow(a, core.nat.sub (b, 1)), 1)#(b == 0);
+
+lam f(n: Nat, x: «n * n * n; Nat»): [] = ();
 lam g(m: Nat, y: «pow (m, 3); Nat»): [] = f (m, y);

--- a/lit/ptrn.mim
+++ b/lit/ptrn.mim
@@ -3,6 +3,8 @@
 plugin core;
 plugin mem;
 
-lam PtrN(n: Nat, T: *): * = (PtrN (core.nat.sub (n, 1), mem.Ptr0 T), T)#(core.ncmp.e (n, 0));
+use core.ops.n;
+
+lam PtrN(n: Nat, T: *): * = (PtrN (n - 1, mem.Ptr0 T), T)#(n == 0);
 
 extern fun foo(m: mem.M 0, p: PtrN (4, I32)): [mem.M 0, PtrN (3, I32)] = return (mem.load (m, p));

--- a/lit/rec.mim
+++ b/lit/rec.mim
@@ -1,9 +1,11 @@
 // RUN: %mim -p opt %s -p ll -o - | %FileCheck %s
 plugin core;
 
-lam is_even(i: Nat): Bool = (is_odd (core.nat.sub (i, 1)), tt)#(core.ncmp.e (i, 0))
+use core.ops.n;
+
+lam is_even(i: Nat): Bool = (is_odd (i - 1), tt)#(i == 0)
 and
-lam is_odd (i: Nat): Bool = (is_even(core.nat.sub (i, 1)), ff)#(core.ncmp.e (i, 0));
+lam is_odd (i: Nat): Bool = (is_even(i - 1), ff)#(i == 0);
 
 extern fun f(): Bool = return (is_even 4);
 // CHECK-DAG: return{{.*}}tt

--- a/lit/regex/match_any_empty.mim
+++ b/lit/regex/match_any_empty.mim
@@ -11,19 +11,19 @@ plugin core;
 plugin regex;
 plugin cps;
 
+use core.ops.u.w;
+
 let Top = ⊤:Nat;
 let re  = regex.conj (regex.lit 'a', regex.disj (regex.empty, regex.any));
 
 extern con main(m: mem.M 0, argc: I32, argv: mem.Ptr («⊤:Nat; mem.Ptr («⊤:Nat; I8», 0)», 0), exit: Cn [mem.M 0, I32]) =
-    (exit, match_argument) # (core.icmp.ug (argc, 1I32)) (m, 0I32)
+    (exit, match_argument) # (argc > 1I32) (m, 0I32)
     where
         con match_argument(m: mem.M 0, _: I32) =
-            let arg1 = mem.lea (argv, core.idx_unsafe 1);
-            let (m, to_match) = mem.load (m, arg1);
+            let (m, to_match) = mem.load (m, mem.lea (argv, core.idx_unsafe 1));
             let (m, matched, pos) = re (m, to_match, 0:(Idx Top));
-            let pos_ptr = mem.lea (to_match, pos);
-            let (m, pos_val) = mem.load (m, pos_ptr);
-            let pos_is_zero = core.icmp.e (pos_val, 0:(Idx 256));
+            let (m, pos_val) = mem.load (m, mem.lea (to_match, pos));
+            let pos_is_zero = pos_val == 0:(Idx 256);
             let matched = core.bit2.and_ core.mode.us (matched, pos_is_zero);
             exit (m, core.conv.u i32 matched);
     end

--- a/lit/regex/match_empty.mim
+++ b/lit/regex/match_empty.mim
@@ -11,19 +11,19 @@ plugin core;
 plugin regex;
 plugin cps;
 
+use core.ops.u.w;
+
 let Top = ⊤:Nat;
 let re  = regex.conj (regex.lit 'a', regex.disj (regex.empty, regex.lit '1'));
 
 extern con main(m: mem.M 0, argc: I32, argv: mem.Ptr («⊤:Nat; mem.Ptr («⊤:Nat; I8», 0)», 0), exit: Cn [mem.M 0, I32]) =
-    (exit, match_argument) # (core.icmp.ug (argc, 1I32)) (m, 0I32)
+    (exit, match_argument) # (argc > 1I32) (m, 0I32)
     where
         con match_argument(m: mem.M 0, _: I32) =
-            let arg1 = mem.lea (argv, core.idx_unsafe 1);
-            let (m, to_match) = mem.load (m, arg1);
+            let (m, to_match) = mem.load (m, mem.lea (argv, core.idx_unsafe 1));
             let (m, matched, pos) = re (m, to_match, 0:(Idx Top));
-            let pos_ptr = mem.lea (to_match, pos);
-            let (m, pos_val) = mem.load (m, pos_ptr);
-            let pos_is_zero = core.icmp.e (pos_val, 0:(Idx 256));
+            let (m, pos_val) = mem.load (m, mem.lea (to_match, pos));
+            let pos_is_zero = pos_val == 0:(Idx 256);
             let matched = core.bit2.and_ core.mode.us (matched, pos_is_zero);
             exit (m, core.conv.u i32 matched);
     end

--- a/lit/regex/match_mail.mim
+++ b/lit/regex/match_mail.mim
@@ -76,7 +76,7 @@ extern con main(m: mem.M 0, argc: I32, argv: mem.Ptr («⊤:Nat; mem.Ptr («⊤:
             strlen(m, to_match, exit_me)
             where
             con exit_me(m: mem.M 0, len: I32) =
-                exit (m, (core.idx i32 0 255, core.wrap.sub i32 (len, core.conv.u i32 pos))#matched)
+                exit (m, (core.idx 0 i32 255, core.wrap.sub i32 (len, core.conv.u i32 pos))#matched)
             end
     end;
 

--- a/lit/regex/match_mail.mim
+++ b/lit/regex/match_mail.mim
@@ -20,6 +20,8 @@ plugin core;
 plugin regex;
 plugin cps;
 
+use core.ops.u.w;
+
 let Top = ⊤:Nat;
 
 // [a-zA-Z0-9]
@@ -67,11 +69,10 @@ let re = regex.conj (letterOrDigit,
 extern con strlen[mem.M 0, mem.Ptr («⊤:Nat; I8», 0), Cn [mem.M 0, I32]];
 
 extern con main(m: mem.M 0, argc: I32, argv: mem.Ptr («⊤:Nat; mem.Ptr («⊤:Nat; I8», 0)», 0), exit: Cn [mem.M 0, I32]) =
-    (exit, match_argument) # (core.icmp.ug (argc, 1I32)) (m, 0I32)
+    (exit, match_argument) # (argc > 1I32) (m, 0I32)
     where
         con match_argument(m: mem.M 0, _: I32) =
-            let arg1 = mem.lea (argv, core.idx_unsafe 1);
-            let (m, to_match) = mem.load (m, arg1);
+            let (m, to_match) = mem.load (m, mem.lea (argv, core.idx_unsafe 1));
             let (m, matched, pos) = re (m, to_match, core.idx_unsafe 0);
             strlen(m, to_match, exit_me)
             where

--- a/lit/regex/match_manual.mim
+++ b/lit/regex/match_manual.mim
@@ -10,61 +10,62 @@ plugin core;
 plugin regex;
 plugin cps;
 
+use core.ops.u.nw;
+
 let Top = ⊤:Nat;
 
 // matches (a|b)+a
 
 extern con main(m: mem.M 0, argc: I32, argv: mem.Ptr («⊤:Nat; mem.Ptr («⊤:Nat; I8», 0)», 0), exit: Cn [mem.M 0, I32]) =
-    (exit, match_argument) # (core.icmp.ug (argc, 1I32)) (m, 0I32)
+    (exit, match_argument) # (argc > 1I32) (m, 0I32)
     where
         con match_argument(m: mem.M 0, _: I32) =
-            let arg1             = mem.lea (argv, core.idx_unsafe 1);
-            let (m, to_match) = mem.load (m, arg1);
+            let (m, to_match) = mem.load (m, mem.lea (argv, core.idx_unsafe 1));
             start (m, 0I32)
             where
                 con start(m: mem.M 0, i: I32) =
                     let ptr       = mem.lea (to_match, core.bitcast (Idx ⊤:Nat) i);
                     let (m, c) = mem.load (m, ptr);
-                    let new_i     = core.wrap.add core.mode.nuw (i, 1I32);
-                    let is_end    = core.icmp.e (c, '\0');
+                    let new_i     = i + 1I32;
+                    let is_end    = c == '\0';
                     (not_end, error)#is_end (m, new_i)
                     where
                         con not_end(m: mem.M 0, i: I32) =
-                            let is_match_a_or_b = core.bit2.or_ 2 (core.icmp.e (c, 'a'), core.icmp.e (c, 'b'));
+                            let is_match_a_or_b = core.bit2.or_ 2 (c == 'a', c == 'b');
                             (error, state1)#is_match_a_or_b (m, i)
                             where
                                 con state1(m: mem.M 0, i: I32) =
                                     let ptr       = mem.lea (to_match, core.bitcast (Idx ⊤:Nat) i);
                                     let (m, c) = mem.load (m, ptr);
-                                    let new_i     = core.wrap.add core.mode.nuw (i, 1I32);
-                                    let is_end    = core.icmp.e (c, '\0');
+                                    let new_i     = i + 1I32;
+                                    let is_end    = c == '\0';
                                     (not_end, error)#is_end (m, new_i)
                                     where
                                         con not_end(m: mem.M 0, i: I32) =
-                                            let is_match_a = core.icmp.e (c, 'a');
+                                            let is_match_a = c == 'a';
                                             (not_a, state2)#is_match_a (m, i)
                                             where
                                                 con state2(m: mem.M 0, i: I32) =
                                                     let ptr       = mem.lea (to_match, core.bitcast (Idx ⊤:Nat) i);
                                                     let (m, c)  = mem.load (m, ptr);
-                                                    let new_i     = core.wrap.add core.mode.nuw (i, 1I32);
-                                                    let is_end    = core.icmp.e (c, '\0');
+                                                    let new_i     = i + 1I32;
+                                                    let is_end    = c == '\0';
                                                     (not_end, accept)#is_end (m, new_i)
                                                     where
                                                         con not_end(m: mem.M 0, i: I32) =
-                                                            let is_match_a = core.icmp.e (c, 'a');
+                                                            let is_match_a = c == 'a';
                                                             (not_a, state2)#is_match_a (m, i);
 
                                                         con accept(m: mem.M 0, _: I32) =
                                                             exit (m, 1I32);
 
                                                         con not_a(m: mem.M 0, i: I32) =
-                                                            let is_match_b = core.icmp.e (c, 'b');
+                                                            let is_match_b = c == 'b';
                                                             (error, state1)#is_match_b (m, i);
                                                     end
                                             end;
                                         con not_a(m: mem.M 0, i: I32) =
-                                            let is_match_b = core.icmp.e (c, 'b');
+                                            let is_match_b = c == 'b';
                                             (error, state1)#is_match_b (m, i);
                                     end
                             end

--- a/lit/regex/match_test10.mim
+++ b/lit/regex/match_test10.mim
@@ -20,7 +20,7 @@ extern con main(m: mem.M 0, argc: I32, argv: mem.Ptr («⊤:Nat; mem.Ptr («⊤:
     where
         fun match_regex(len: Nat) (m: mem.M 0, str: mem.Ptr0 «len; Char»): [mem.M 0, Bool] =
             let (m, matched, pos) = pattern (m, str, 0:(Idx len));
-            let end_ = core.idx len 0 (core.nat.sub (len, 1));
+            let end_ = core.idx 0 len (core.nat.sub (len, 1));
             return (m, core.bit2.and_ 0 (core.icmp.e (pos, end_), matched));
         con exiting(m: mem.M 0, return: Bool) = exit (m, core.conv.u i32 return)
     end

--- a/lit/rules/rules.mim
+++ b/lit/rules/rules.mim
@@ -2,6 +2,8 @@
 
 plugin core;
 
-rule foo (a: Nat): (core.nat.add (a, a)) => (core.nat.mul (a, 2));
+use core.ops.n;
+
+rule foo (a: Nat): (a + a) => (a * 2);
 
 extern lam rules(): Rule Nat = foo;

--- a/lit/tensor/dot_symbolic_div.mim
+++ b/lit/tensor/dot_symbolic_div.mim
@@ -13,12 +13,14 @@ plugin tensor;
 plugin affine;
 plugin mem;
 
+use core.ops.n;
+
 lam nat_ring (): tensor.Ring = (Nat, 0, core.nat.add, core.nat.mul);
 
 // CHECK-DAG: extern fun mm_pad
 extern fun mm_pad {m n l: Nat} (
-        a: «m, core.nat.mul (core.nat.div (core.nat.add (n, 3), 4), 4); Nat»,
-        b: «core.nat.mul (core.nat.div (core.nat.add (n, 3), 4), 4), l; Nat»): «m, l; Nat» =
+        a: «m, (n + 3) / 4 * 4; Nat»,
+        b: «(n + 3) / 4 * 4, l; Nat»): «m, l; Nat» =
     return (tensor.product_2d_impl 1 (nat_ring ()) (a, b));
 
 extern lam _compile (): compile.Phase =

--- a/lit/tensor/fc_exec.mim
+++ b/lit/tensor/fc_exec.mim
@@ -24,7 +24,7 @@ let F32 = math.F32;
 
 let R: tensor.Ring = (F32, 0:F32, math.arith.add 0, math.arith.mul 0);
 
-let add  = math.arith.add @f32 0;
+let add  = math.arith.add 0 @f32;
 let fmax = math.extrema.fmax 0;
 
 lam relu (x: F32): F32 = fmax (0:F32, x);

--- a/lit/tensor/fuse_epilogue_bias.mim
+++ b/lit/tensor/fuse_epilogue_bias.mim
@@ -9,14 +9,13 @@ plugin core;
 plugin opt;
 plugin compile;
 
-lam add1 (x: Nat): Nat = core.nat.add (x, 1);
-lam addp (x y: Nat): Nat = core.nat.add (x, y);
+use core.ops.n;
+
+lam add1 (x: Nat): Nat = x + 1;
+lam addp (x y: Nat): Nat = x + y;
 
 extern con f (a: «2, 3; Nat», b: «3, 4; Nat», bias: «2, 4; Nat», return: Cn «2, 4; Nat») =
-    let prod   = tensor.product_2d (Nat, 0, core.nat.add, core.nat.mul) (a, b);
-    let biased = tensor.binary addp (prod, bias);
-    let out    = tensor.unary add1 biased;
-    return out;
+    return (tensor.unary add1 (tensor.binary addp (tensor.product_2d (Nat, 0, core.nat.add, core.nat.mul) (a, b), bias)));
 
 extern lam _compile (): compile.Phase =
     compile.phases ff (

--- a/lit/tensor/fuse_map.mim
+++ b/lit/tensor/fuse_map.mim
@@ -7,13 +7,13 @@ plugin core;
 plugin opt;
 plugin compile;
 
-lam add1 (x: Nat): Nat = core.nat.add (x, 1);
-lam mul2 (x: Nat): Nat = core.nat.mul (x, 2);
+use core.ops.n;
+
+lam add1 (x: Nat): Nat = x + 1;
+lam mul2 (x: Nat): Nat = x * 2;
 
 extern con f (v: «2; «3; Nat»», return: Cn «2; «3; Nat»») =
-    let inner = tensor.unary add1 v;
-    let outer = tensor.unary mul2 inner;
-    return outer;
+    return (tensor.unary mul2 (tensor.unary add1 v));
 
 extern lam _compile (): compile.Phase =
     compile.phases ff (

--- a/lit/tensor/fuse_multi_input.mim
+++ b/lit/tensor/fuse_multi_input.mim
@@ -17,8 +17,7 @@ lam add  (xs: [Nat, Nat]): Nat = core.nat.add xs;
 extern con f (v1 v2: «2; «3; Nat»», return: Cn «2; «3; Nat»») =
     let inner1 = tensor.unary add1 v1;
     let inner2 = tensor.unary mul2 v2;
-    let outer  = tensor.binary add (inner1, inner2);
-    return outer;
+    return (tensor.binary add (inner1, inner2));
 
 extern lam _compile (): compile.Phase =
     compile.phases ff (

--- a/lit/tensor/fuse_multi_input.mim
+++ b/lit/tensor/fuse_multi_input.mim
@@ -8,8 +8,10 @@ plugin core;
 plugin opt;
 plugin compile;
 
-lam add1 (x: Nat): Nat = core.nat.add (x, 1);
-lam mul2 (x: Nat): Nat = core.nat.mul (x, 2);
+use core.ops.n;
+
+lam add1 (x: Nat): Nat = x + 1;
+lam mul2 (x: Nat): Nat = x * 2;
 lam add  (xs: [Nat, Nat]): Nat = core.nat.add xs;
 
 extern con f (v1 v2: «2; «3; Nat»», return: Cn «2; «3; Nat»») =

--- a/lit/tensor/fuse_nested.mim
+++ b/lit/tensor/fuse_nested.mim
@@ -8,10 +8,12 @@ plugin core;
 plugin opt;
 plugin compile;
 
-lam add1 (x: Nat): Nat = core.nat.add (x, 1);
-lam mul2 (x: Nat): Nat = core.nat.mul (x, 2);
+use core.ops.n;
 
-fun sum_reduce (acc x: Nat)@tt: Nat = return (core.nat.add (acc, x));
+lam add1 (x: Nat): Nat = x + 1;
+lam mul2 (x: Nat): Nat = x * 2;
+
+fun sum_reduce (acc x: Nat)@tt: Nat = return (acc + x);
 
 extern con f (v: «2; «3; Nat»», return: Cn «2; Nat») =
     let inner1 = tensor.unary add1 v;

--- a/lit/tensor/fuse_read_through.mim
+++ b/lit/tensor/fuse_read_through.mim
@@ -14,8 +14,10 @@ plugin core;
 plugin opt;
 plugin compile;
 
-lam add1 (x: Nat): Nat = core.nat.add (x, 1);
-lam addp (x y: Nat): Nat = core.nat.add (x, y);
+use core.ops.n;
+
+lam add1 (x: Nat): Nat = x + 1;
+lam addp (x y: Nat): Nat = x + y;
 
 extern con f (a: «2, 3; Nat», b: «4, 3; Nat», bias: «4; Nat», return: Cn «2, 4; Nat») =
     let wt = tensor.transpose_2d b;

--- a/lit/tensor/fuse_reduce_map.mim
+++ b/lit/tensor/fuse_reduce_map.mim
@@ -7,9 +7,11 @@ plugin core;
 plugin opt;
 plugin compile;
 
-lam add1 (x: Nat): Nat = core.nat.add (x, 1);
+use core.ops.n;
 
-fun sum_reduce (acc x: Nat)@tt: Nat = return (core.nat.add (acc, x));
+lam add1 (x: Nat): Nat = x + 1;
+
+fun sum_reduce (acc x: Nat)@tt: Nat = return (acc + x);
 
 extern con f (v: «2; «3; Nat»», return: Cn «2; Nat») =
     let inner = tensor.unary add1 v;

--- a/lit/tensor/fuse_reduce_map_transposed.mim
+++ b/lit/tensor/fuse_reduce_map_transposed.mim
@@ -8,9 +8,11 @@ plugin core;
 plugin opt;
 plugin compile;
 
-lam add1 (x: Nat): Nat = core.nat.add (x, 1);
+use core.ops.n;
 
-fun sum_reduce (acc x: Nat)@tt: Nat = return (core.nat.add (acc, x));
+lam add1 (x: Nat): Nat = x + 1;
+
+fun sum_reduce (acc x: Nat)@tt: Nat = return (acc + x);
 
 extern con f (v: «3; «2; Nat»», return: Cn «2; Nat») =
     let inner = tensor.unary add1 v;

--- a/lit/tensor/fuse_skip_epilogue_shared.mim
+++ b/lit/tensor/fuse_skip_epilogue_shared.mim
@@ -8,14 +8,14 @@ plugin core;
 plugin opt;
 plugin compile;
 
-lam add1 (x: Nat): Nat = core.nat.add (x, 1);
-lam dbl (x: Nat): Nat = core.nat.mul (x, 2);
+use core.ops.n;
+
+lam add1 (x: Nat): Nat = x + 1;
+lam dbl (x: Nat): Nat = x * 2;
 
 extern con f (a: «2, 3; Nat», b: «3, 4; Nat», return: Cn [«2, 4; Nat», «2, 4; Nat»]) =
     let prod = tensor.product_2d (Nat, 0, core.nat.add, core.nat.mul) (a, b);
-    let out1 = tensor.unary add1 prod;
-    let out2 = tensor.unary dbl prod;
-    return (out1, out2);
+    return (tensor.unary add1 prod, tensor.unary dbl prod);
 
 extern lam _compile (): compile.Phase =
     compile.phases ff (

--- a/lit/tensor/fuse_skip_epilogue_shared_read.mim
+++ b/lit/tensor/fuse_skip_epilogue_shared_read.mim
@@ -10,15 +10,15 @@ plugin core;
 plugin opt;
 plugin compile;
 
-lam add1 (x: Nat): Nat = core.nat.add (x, 1);
-lam dbl (x: Nat): Nat = core.nat.mul (x, 2);
+use core.ops.n;
+
+lam add1 (x: Nat): Nat = x + 1;
+lam dbl (x: Nat): Nat = x * 2;
 
 extern con f (a: «2, 3; Nat», b: «3, 4; Nat», return: Cn [«8; Nat», «8; Nat»]) =
     let prod = tensor.product_2d (Nat, 0, core.nat.add, core.nat.mul) (a, b);
     let flat = tensor.reshape (2, 4) 8 prod;
-    let out1 = tensor.unary add1 flat;
-    let out2 = tensor.unary dbl flat;
-    return (out1, out2);
+    return (tensor.unary add1 flat, tensor.unary dbl flat);
 
 extern lam _compile (): compile.Phase =
     compile.phases ff (

--- a/lit/tensor/fuse_skip_reduction.mim
+++ b/lit/tensor/fuse_skip_reduction.mim
@@ -11,9 +11,11 @@ plugin opt;
 plugin affine;
 plugin compile;
 
-fun sum_reduce (acc x: Nat)@tt: Nat = return (core.nat.add (acc, x));
+use core.ops.n;
 
-fun add1_of (acc: Nat, y: «1; Nat»)@tt: Nat = return (core.nat.add (y#0_1, 1));
+fun sum_reduce (acc x: Nat)@tt: Nat = return (acc + x);
+
+fun add1_of (acc: Nat, y: «1; Nat»)@tt: Nat = return (y#0_1 + 1);
 
 extern con f (v: «2; «3; Nat»», return: Cn «2, 2; Nat») =
     // inner[i] = Σ_j v[i, j]: one output loop (bound 2), one reduction loop (bound 3)

--- a/lit/tensor/fuse_strip_pack.mim
+++ b/lit/tensor/fuse_strip_pack.mim
@@ -11,8 +11,10 @@ plugin affine;
 plugin opt;
 plugin compile;
 
-fun addf (x: Nat, y: «1; Nat»)@tt: Nat = return (core.nat.add (x, y#0₁));
-lam add1 (x: Nat): Nat = core.nat.add (x, 1);
+use core.ops.n;
+
+fun addf (x: Nat, y: «1; Nat»)@tt: Nat = return (x + y#0₁);
+lam add1 (x: Nat): Nat = x + 1;
 lam mo (i k: affine.Index): «1; affine.Index» = i;
 lam mi (i k: affine.Index): «2; affine.Index» = (i, k);
 

--- a/lit/tensor/gather_scatter_exec.mim
+++ b/lit/tensor/gather_scatter_exec.mim
@@ -7,6 +7,8 @@ plugin core;
 plugin tensor;
 plugin mem;
 
+use core.ops.u.w;
+
 extern con main (m: mem.M 0, argc: I32,
                  argv: mem.Ptr (mem.Ptr (I8, 0), 0),
                  return: Cn [mem.M 0, I32]) =
@@ -16,8 +18,4 @@ extern con main (m: mem.M 0, argc: I32,
     let gathered = tensor.gather ((2, 3), (2, 2)) 1_2 (input, index);
     let scattered = tensor.scatter ((2, 3), (2, 2), (2, 2)) 1_2
         (input, index, updates);
-    let a = tensor.get ((0_2, 0_2), gathered);
-    let b = tensor.get ((1_2, 0_2), gathered);
-    let c = tensor.get ((0_2, 0_3), scattered);
-    let d = tensor.get ((1_2, 1_3), scattered);
-    return (m, core.wrap.add 0 (core.wrap.add 0 (a, b), core.wrap.add 0 (c, d)));
+    return (m, tensor.get ((0_2, 0_2), gathered) + tensor.get ((1_2, 0_2), gathered) + (tensor.get ((0_2, 0_3), scattered) + tensor.get ((1_2, 1_3), scattered)));

--- a/lit/tensor/hlo_train.mim
+++ b/lit/tensor/hlo_train.mim
@@ -23,6 +23,7 @@ plugin cps;
 plugin math;
 plugin btensor;
 use tensor;
+use math.ops.none;
 
 let f32 = math.f32;
 let F32 = math.F32;
@@ -74,4 +75,4 @@ extern fun main_hlo (w: «8; «3; F32»», b: «3; F32», x: «4; «8; F32»», 
     let s1 = tensor.get   ((0₃, ), b2);
     let s2 = tensor.get ((0₄, 0₈), dx);
     let s3 = tensor.get   ((0₄, ), sel);
-    return (math.arith.add 0 (math.arith.add 0 (s0, s1), math.arith.add 0 (s2, s3)));
+    return ((s0 + s1) + (s2 + s3));

--- a/lit/tensor/map_reduce.mim
+++ b/lit/tensor/map_reduce.mim
@@ -13,7 +13,9 @@ plugin cps;
 plugin affine;
 plugin mem;
 
-fun add  (x: I32, y: «1; I32»)@tt = return (core.wrap.add 0 (x, y#0₁));
+use core.ops.u.w;
+
+fun add  (x: I32, y: «1; I32»)@tt = return (x + y#0₁);
 fun copy (x: I32, y: «1; I32»)@tt = return (y#0₁);
 lam id1 (i: affine.Index): «1; affine.Index» = i;
 lam id1i(i, j: affine.Index): «1; affine.Index» = i;

--- a/lit/tensor/vgg16.mim
+++ b/lit/tensor/vgg16.mim
@@ -26,7 +26,7 @@ let F32 = math.F32;
 
 let R: tensor.Ring = (F32, 0:F32, math.arith.add 0, math.arith.mul 0);
 
-let add     = math.arith.add @f32 0;
+let add     = math.arith.add 0 @f32;
 let fmax    = math.extrema.fmax 0;
 let neg_inf = 0xFF800000:F32;
 

--- a/lit/tuple/scalarize_pi_twin.mim
+++ b/lit/tuple/scalarize_pi_twin.mim
@@ -2,6 +2,8 @@
 plugin core;
 plugin mem;
 
+use core.ops.u.w;
+
 /// A `Cn` *type expression* used to emit a **mutable** Pi, while the Pi of a `con` *declaration* of the very
 /// same signature came out **immutable** (LamDecl::emit_body() already immutabilized its own).
 /// Two alpha-equivalent yet distinct defs - and Scalarize decides per def, flattening only the immutable twin
@@ -15,7 +17,7 @@ extern con main (m: mem.M 0, n: I32, return: Cn [mem.M 0, I32]) =
     con use_pb (m: mem.M 0, pb: Pb) =
         con k (m: mem.M 0, prs: [I32, I32]) =
             let (a, b) = prs;
-            return (m, core.wrap.add 0 (a, b));
+            return (m, a + b);
         pb (m, n, k);
 
     con id_pb  (m: mem.M 0, x: I32, k: PbVec) = k (m, (x, x));
@@ -23,8 +25,7 @@ extern con main (m: mem.M 0, n: I32, return: Cn [mem.M 0, I32]) =
 
     // `pb` is selected at runtime, so nothing here can be inlined away:
     // the flattened signature has to survive into the output.
-    let cond = core.icmp.ul (n, 3I32);
-    use_pb (m, (id_pb, zero_pb)#cond);
+    use_pb (m, (id_pb, zero_pb)#(n < 3I32));
 
 // Both twins are one immutable Pi now, so the pullback continuation is flattened consistently:
 // `[mem.M 0, «2; I32»]` becomes `[mem.M 0, I32, I32]` at the binder *and* at both call sites

--- a/lit/vec/normalize.mim
+++ b/lit/vec/normalize.mim
@@ -4,6 +4,8 @@ plugin option as o;
 plugin refly;
 plugin core;
 
+use core.ops.n;
+
 let l = vec.fold.l core.nat.add (0, (1, 2, 3, 4, 5));
 let r = vec.fold.r core.nat.add ((1, 2, 3, 4, 5), 0);
 let _ = refly.equiv.struc_eq (l, 15);
@@ -14,13 +16,13 @@ let r2 = vec.fold.r core.nat.mul («4; 2», 1);
 let _ = refly.equiv.struc_eq (l2, 16);
 let _ = refly.equiv.struc_eq (r2, 16);
 
-let e1 = vec.scan.exists (λ (n: Nat): Bool = core.ncmp.e (n, 3)) (0, 1, 2, 3, 4);
-let e2 = vec.scan.exists (λ (n: Nat): Bool = core.ncmp.e (n, 5)) (0, 1, 2, 3, 4);
+let e1 = vec.scan.exists (λ (n: Nat): Bool = n == 3) (0, 1, 2, 3, 4);
+let e2 = vec.scan.exists (λ (n: Nat): Bool = n == 5) (0, 1, 2, 3, 4);
 let _  = refly.equiv.struc_eq (e1, tt);
 let _  = refly.equiv.struc_eq (e2, ff);
 
-let a1 = vec.scan.for_all (λ (n: Nat): Bool = core.ncmp.ge (n, 0)) (0, 1, 2, 3, 4);
-let a2 = vec.scan.for_all (λ (n: Nat): Bool = core.ncmp.l  (n, 3)) (0, 1, 2, 3, 4);
+let a1 = vec.scan.for_all (λ (n: Nat): Bool = n >= 0) (0, 1, 2, 3, 4);
+let a2 = vec.scan.for_all (λ (n: Nat): Bool = n < 3) (0, 1, 2, 3, 4);
 let _  = refly.equiv.struc_eq (a1, tt);
 let _  = refly.equiv.struc_eq (a2, ff);
 

--- a/src/mim/plug/autodiff/autodiff.mim
+++ b/src/mim/plug/autodiff/autodiff.mim
@@ -122,7 +122,7 @@ mod diff {
     /// The derivative of core.wrap.add:
     /// s ↦ (s, s)
     ///
-    anx fun core_wrap_add {s: Nat} (m: Nat) (ab: «2; Idx s»)@tt: [Idx s, Cn [Idx s, Cn «2; Idx s»]] =
+    anx fun core_wrap_add (m: Nat) {s: Nat} (ab: «2; Idx s»)@tt: [Idx s, Cn [Idx s, Cn «2; Idx s»]] =
         return (core.wrap.add m ab, fn (i: Idx s)@tt: «2; Idx s» = return ‹2; i›);
     ///
     /// #### autodiff.diff.core_wrap_mul
@@ -130,6 +130,6 @@ mod diff {
     /// The derivative of core.wrap.mul:
     /// s ↦ (s*b, s*a)
     ///
-    anx fun core_wrap_mul {s: Nat} (m: Nat) (a b: Idx s) as ab@tt: [Idx s, Cn [Idx s, Cn «2; Idx s»]] =
+    anx fun core_wrap_mul (m: Nat) {s: Nat} (a b: Idx s) as ab@tt: [Idx s, Cn [Idx s, Cn «2; Idx s»]] =
         return (core.wrap.mul m ab, fn (i: Idx s)@tt: «2; Idx s» = return (core.wrap.mul m (i, b), core.wrap.mul m (i, a)));
 }

--- a/src/mim/plug/btensor/btensor.mim
+++ b/src/mim/plug/btensor/btensor.mim
@@ -84,7 +84,7 @@ lam range_nest (r: Nat, Sr: «r; Nat») (A: *) (loop: ForT A, lo hi: Nat)
     lam wrap (d: Nat, w: Cn [«r; I32», mem.M 0, A, Cn [mem.M 0, A]])
            : Cn [«r; I32», mem.M 0, A, Cn [mem.M 0, A]] =
         con level (pref: «r; I32», m: mem.M 0, acc: A, k: Cn [mem.M 0, A]) =
-            loop lbody lexit (0I32, core.bitcast I32 (Sr#(core.idx r 0 d)), 1I32, (m, acc))
+            loop lbody lexit (0I32, core.bitcast I32 (Sr#(core.idx 0 r d)), 1I32, (m, acc))
             where
                 con lbody (iv: I32, macc: [mem.M 0, A], yield: Cn [mem.M 0, A]) =
                     let pref2 = ‹j: r; core.select (core.ncmp.e (core.bitcast Nat j, d), iv, pref#j)›;
@@ -112,7 +112,7 @@ lam range_unroll (r: Nat, Sr: «r; Nat») (A: *) (lo hi: Nat)
                                                      core.bitcast I32 i, pref#j)›;
                     w (pref2, m2, a2, kk);
                 at;
-            let t  = Sr#(core.idx r 0 d);
+            let t  = Sr#(core.idx 0 r d);
             let ks = ‹i: t; core.bitcast Nat i›;
             (vec.fold.r @(Cn [mem.M 0, A], Nat) @t step (ks, k)) (m, acc);
         level;
@@ -154,7 +154,7 @@ anx lam mr_nest (ro rr: Nat, Sr: «core.nat.add (ro, rr); Nat», To U: *) (vdim 
         // `vd` is `vdim` clamped through the dispatch condition: the non-selected branch is still
         // ELABORATED, so its body must be type-sane even when `vdim` is the out-of-range sentinel.
         let vec_ok = core.bit2.and_ 2 (core.ncmp.e (core.nat.add (vdim, 1), ro),
-                                        core.ncmp.ne (Sr#(core.idx r 0 ((0, vdim)#(core.ncmp.l (vdim, r)))), 1));
+                                        core.ncmp.ne (Sr#(core.idx 0 r ((0, vdim)#(core.ncmp.l (vdim, r)))), 1));
         let vd = (0, vdim)#vec_ok;
 
         // CLASSIC: reduction loops inside all output loops, one accumulator cell at a time; the
@@ -169,8 +169,8 @@ anx lam mr_nest (ro rr: Nat, Sr: «core.nat.add (ro, rr); Nat», To U: *) (vdim 
         // VECTORIZED: the vector dim as the innermost loop over a row of accumulators — refill the
         // row per output row, fold whole rows in lockstep, then write the row back cell by cell.
         con vectorized (mem0: mem.M 0, u0: U, done: Cn [mem.M 0, U])@tt =
-            let Sv = Sr#(core.idx r 0 vd);
-            let vi_of = lm (pref: «r; I32»): Idx Sv = core.conv.u Sv (pref#(core.idx r 0 vd));
+            let Sv = Sr#(core.idx 0 r vd);
+            let vi_of = lm (pref: «r; I32»): Idx Sv = core.conv.u Sv (pref#(core.idx 0 r vd));
             let (mem1, row) = buffer.alloc (1, Sv, To) mem0;
             con at_row (pref: «r; I32», m: mem.M 0, u: U, k: Cn [mem.M 0, U]) =
                 con fill (pref2: «r; I32», memf: mem.M 0, uf: U, kf: Cn [mem.M 0, U]) =
@@ -205,17 +205,17 @@ anx lam mr_nest (ro rr: Nat, Sr: «core.nat.add (ro, rr); Nat», To U: *) (vdim 
         let sd_r    = core.nat.add (vdim, 1);
         let sd_c    = (0, sd_r)#(core.ncmp.l (sd_r, r));
         let block_ok = core.bit2.and_ 2 (core.ncmp.e (core.nat.add (vdim, 2), ro),
-                      core.bit2.and_ 2 (core.ncmp.ne (Sr#(core.idx r 0 pd_c), 1),
-                                         core.ncmp.ne (Sr#(core.idx r 0 sd_c), 1)));
+                      core.bit2.and_ 2 (core.ncmp.ne (Sr#(core.idx 0 r pd_c), 1),
+                                         core.ncmp.ne (Sr#(core.idx 0 r sd_c), 1)));
 
         con blocked (mem0: mem.M 0, u0: U, done: Cn [mem.M 0, U])@tt =
-            let Sp = Sr#(core.idx r 0 pd_c);
-            let Sv = Sr#(core.idx r 0 sd_c);
+            let Sp = Sr#(core.idx 0 r pd_c);
+            let Sv = Sr#(core.idx 0 r sd_c);
             let Np = core.nat.mul (Sp, Sv);
             let vi_of = lm (pref: «r; I32»): Idx Np =
                 core.conv.u Np (core.wrap.add 0
-                    (core.wrap.mul 0 (pref#(core.idx r 0 pd_c), core.bitcast I32 Sv),
-                     pref#(core.idx r 0 sd_c)));
+                    (core.wrap.mul 0 (pref#(core.idx 0 r pd_c), core.bitcast I32 Sv),
+                     pref#(core.idx 0 r sd_c)));
             let (mem1, panel) = buffer.alloc (1, Np, To) mem0;
             con at_block (pref: «r; I32», m: mem.M 0, u: U, k: Cn [mem.M 0, U]) =
                 con fill (pref2: «r; I32», memf: mem.M 0, uf: U, kf: Cn [mem.M 0, U]) =
@@ -266,7 +266,7 @@ anx lam mr_nest (ro rr: Nat, Sr: «core.nat.add (ro, rr); Nat», To U: *) (vdim 
         let Sr_rv     = ‹j: r; let jj  = core.bitcast Nat j;
                                let jam = core.bit2.and_ 2 (core.ncmp.le (rv_bd, jj), core.ncmp.l (jj, ro));
                                (Sr#j, (1, Sr#j)#redvec_ok)#jam›;
-        lam rv_mul (d: Nat, acc: Nat): Nat = core.nat.mul (acc, Sr_rv#(core.idx r 0 d));
+        lam rv_mul (d: Nat, acc: Nat): Nat = core.nat.mul (acc, Sr_rv#(core.idx 0 r d));
         let rv_ds = ‹i: rv_j; core.nat.add (rv_bd, core.bitcast Nat i)›;
         let Sb    = vec.fold.r @(Nat, Nat) @rv_j rv_mul (rv_ds, 1);
 
@@ -274,8 +274,8 @@ anx lam mr_nest (ro rr: Nat, Sr: «core.nat.add (ro, rr); Nat», To U: *) (vdim 
             // Flatten a loop vector's jam coordinates into the panel (any per-dim-bounded
             // linearization is a bijection into «Sb»; the exact order is internal to the panel).
             lam rv_lin (pref: «r; I32») (d: Nat, acc: I32): I32 =
-                core.wrap.add 0 (core.wrap.mul 0 (acc, core.bitcast I32 (Sr_rv#(core.idx r 0 d))),
-                                  pref#(core.idx r 0 d));
+                core.wrap.add 0 (core.wrap.mul 0 (acc, core.bitcast I32 (Sr_rv#(core.idx 0 r d))),
+                                  pref#(core.idx 0 r d));
             let bi_of = lm (pref: «r; I32»): Idx Sb =
                 core.conv.u Sb (vec.fold.r @(I32, Nat) @rv_j (rv_lin pref) (rv_ds, 0I32));
             let (mem1, panel) = buffer.alloc (1, Sb, To) mem0;
@@ -375,7 +375,7 @@ axm map_reduce: {nis: Nat}
 /// e.g. `((0, 2), (2, 1))` for the two inputs of a matrix product.
 /// tensor.proj_map is an alias for this lam.
 anx lam proj_map {n r: Nat} (subs: «r; Nat») (o: «n; affine.Index»): «r; affine.Index» =
-    ‹j: r; o#(core.idx n 0 (subs#j))›;
+    ‹j: r; o#(core.idx 0 n (subs#j))›;
 ///
 /// ### product_2d
 ///

--- a/src/mim/plug/core/core.mim
+++ b/src/mim/plug/core/core.mim
@@ -302,3 +302,98 @@ anx lam select {T: *} (cond: Bool, t f: T): T = (f, t)#cond;
 /// core.select one level up, to select between types.
 ///
 anx lam Select {T: □} (cond: Bool, t f: T): T = (f, t)#cond;
+///
+/// ### core.ops
+///
+/// Bindings for the infix operators, which are sugar for an application of the escaped name.
+/// `use` the module matching the domain at hand:
+///
+/// | Module          | Domain                                     |
+/// |-----------------|--------------------------------------------|
+/// | `core.ops.n`    | `Nat`                                      |
+/// | `core.ops.s.w`  | signed `Idx s`, wrap around                |
+/// | `core.ops.s.nw` | signed `Idx s`, `core.mode.nsw`            |
+/// | `core.ops.u.w`  | unsigned `Idx s`, wrap around              |
+/// | `core.ops.u.nw` | unsigned `Idx s`, `core.mode.nuw`          |
+///
+/// `core.ops.s`/`core.ops.u` offer only those operators that don't depend on the mode.
+/// `Idx s` has no `/` and `%`, since core.div expects a `mem.M`.
+///
+pub mod ops {
+    pub mod n {
+        pub let `+  =  nat.add;
+        pub let `-  =  nat.sub;
+        pub let `*  =  nat.mul;
+        pub let `/  =  nat.div;
+        pub let `%  =  nat.rem;
+        pub let `== = ncmp.e;
+        pub let `!= = ncmp.ne;
+        pub let `<  = ncmp.l;
+        pub let `<= = ncmp.le;
+        pub let `>  = ncmp.g;
+        pub let `>= = ncmp.ge;
+    }
+
+    mod eq {
+        pub let `== = icmp.e;
+        pub let `!= = icmp.ne;
+    }
+
+    mod signed {
+        use eq;
+        pub let `>> = shr.a;
+        pub let `<  = icmp.sl;
+        pub let `<= = icmp.sle;
+        pub let `>  = icmp.sg;
+        pub let `>= = icmp.sge;
+    }
+
+    mod unsigned {
+        use eq;
+        pub let `>> = shr.l;
+        pub let `<  = icmp.ul;
+        pub let `<= = icmp.ule;
+        pub let `>  = icmp.ug;
+        pub let `>= = icmp.uge;
+    }
+
+    pub mod s {
+        use signed;
+
+        pub mod w {
+            use signed;
+            pub let `+  = wrap.add mode.us;
+            pub let `-  = wrap.sub mode.us;
+            pub let `*  = wrap.mul mode.us;
+            pub let `<< = wrap.shl mode.us;
+        }
+
+        pub mod nw {
+            use signed;
+            pub let `+  = wrap.add mode.nsw;
+            pub let `-  = wrap.sub mode.nsw;
+            pub let `*  = wrap.mul mode.nsw;
+            pub let `<< = wrap.shl mode.nsw;
+        }
+    }
+
+    pub mod u {
+        use unsigned;
+
+        pub mod w {
+            use unsigned;
+            pub let `+  = wrap.add mode.us;
+            pub let `-  = wrap.sub mode.us;
+            pub let `*  = wrap.mul mode.us;
+            pub let `<< = wrap.shl mode.us;
+        }
+
+        pub mod nw {
+            use unsigned;
+            pub let `+  = wrap.add mode.nuw;
+            pub let `-  = wrap.sub mode.nuw;
+            pub let `*  = wrap.mul mode.nuw;
+            pub let `<< = wrap.shl mode.nuw;
+        }
+    }
+}

--- a/src/mim/plug/core/core.mim
+++ b/src/mim/plug/core/core.mim
@@ -303,7 +303,7 @@ anx lam select {T: *} (cond: Bool, t f: T): T = (f, t)#cond;
 ///
 anx lam Select {T: □} (cond: Bool, t f: T): T = (f, t)#cond;
 ///
-/// ### core.ops
+/// ## ops
 ///
 /// Bindings for the infix operators, which are sugar for an application of the escaped name.
 /// `use` the module matching the domain at hand:

--- a/src/mim/plug/core/core.mim
+++ b/src/mim/plug/core/core.mim
@@ -61,7 +61,8 @@ axm ncmp.(gle = f, glE =  e, gLe =  l, gLE = le,
 /// ### Mode
 ///
 /// A common problem when dealing with integer operations is [overflow](https://en.wikipedia.org/wiki/Integer_overflow).
-/// All operations that may overflow have an additional parameter `m` - [mode](@ref mim::plug::core::Mode) - of type `Nat` that determines the exact desired behavior in the case of an overflow.
+/// All operations that may overflow take a leading parameter `m` - [mode](@ref mim::plug::core::Mode) - of type `Nat` that determines the exact desired behavior in the case of an overflow.
+/// It comes first so that currying it - `core.wrap.add 0` - still yields a value polymorphic in `s`.
 ///
 pub mod mode {
     anx let us = 0b00; // wrap around - both signed and unsigned
@@ -77,7 +78,7 @@ pub mod mode {
 ///
 /// Creates a literal of type `Idx s` from `l` while obeying mode `m`.
 ///
-axm idx: [s: Nat] → [m: Nat] → [l: Nat] → Idx s, normalize_idx;
+axm idx: [m: Nat] → [s: Nat] → [l: Nat] → Idx s, normalize_idx;
 ///
 /// ### core.idx_unsafe
 ///
@@ -98,7 +99,7 @@ axm idx_unsafe: Nat → Idx ⊤:Nat, normalize_idx_unsafe;
 ///
 /// @todo Add type constraint that `bit1` is only allowed for powers of two.
 ///
-axm bit1.(f, neg, id, t): {s: Nat} → [m: Nat] → Idx s → Idx s, normalize_bit1;
+axm bit1.(f, neg, id, t): [m: Nat] → {s: Nat} → Idx s → Idx s, normalize_bit1;
 ///
 /// ### core.bit2
 ///
@@ -127,7 +128,7 @@ axm bit1.(f, neg, id, t): {s: Nat} → [m: Nat] → Idx s → Idx s, normalize_b
 ///
 axm bit2.( f,      nor, nciff, nfst, niff, nsnd, xor_, nand,
            and_,  nxor,   snd,  iff,  fst, ciff,  or_,    t):
-    {s: Nat} → [m: Nat] → «2; Idx s» → Idx s , normalize_bit2;
+    [m: Nat] → {s: Nat} → «2; Idx s» → Idx s , normalize_bit2;
 ///
 /// ### core.shr
 ///
@@ -146,15 +147,15 @@ axm shr.(a, l): {s: Nat} → «2; Idx s» → Idx s, normalize_shr;
 /// ### core.wrap
 ///
 /// Integer operations that may overflow.
-/// You can specify the desired behavior in the case of an overflow with the curried argument just in front of the actual argument by providing a mim::plug::core::Mode as `Nat`.
+/// You can specify the desired behavior in the case of an overflow with the leading curried argument by providing a mim::plug::core::Mode as `Nat`.
 ///
 /// `shl` uses the same shift-count rule as `core.shr`.
 /// It multiplies the unsigned representative by `2^b` and then wraps modulo `s`.
 /// `nuw` and `nsw` check the unwrapped unsigned and signed results, respectively.
 ///
-axm wrap.(add, sub, mul, shl): {s: Nat} → [m: Nat] → «2; Idx s» → Idx s, normalize_wrap;
+axm wrap.(add, sub, mul, shl): [m: Nat] → {s: Nat} → «2; Idx s» → Idx s, normalize_wrap;
 
-anx lam minus {s: Nat} (m: Nat) (a: Idx s): Idx s = wrap.sub m (0:(Idx s), a);
+anx lam minus (m: Nat) {s: Nat} (a: Idx s): Idx s = wrap.sub m (0:(Idx s), a);
 ///
 /// ### core.div
 ///

--- a/src/mim/plug/core/normalizers.cpp
+++ b/src/mim/plug/core/normalizers.cpp
@@ -471,7 +471,7 @@ const Def* merge_cmps(std::array<std::array<u64, 2>, 2> tab, const Def* a, const
         res >>= (7_u8 - u8(num_bits));
 
         if constexpr (std::is_same_v<Id, math::cmp>)
-            return world.call(math::cmp(res), /*mode*/ a_cmp->decurry()->arg(), a_cmp->arg());
+            return world.call(math::cmp(res), /*mode*/ a_cmp->decurry()->decurry()->arg(), a_cmp->arg());
         else
             return world.call(icmp(Annex::base<icmp>() | res), a_cmp->arg());
     }
@@ -632,7 +632,7 @@ template<bit1 id>
 const Def* normalize_bit1(const Def* type, const Def* c, const Def* a) {
     auto& world = type->world();
     auto callee = c->as<App>();
-    auto s      = callee->decurry()->arg();
+    auto s      = callee->arg();
     // TODO cope with wrap around
 
     if constexpr (id == bit1::id) return a;
@@ -657,7 +657,8 @@ const Def* normalize_bit2(const Def* type, const Def* c, const Def* arg) {
     auto& world = type->world();
     auto callee = c->as<App>();
     auto [a, b] = arg->projs<2>();
-    auto s      = callee->decurry()->arg();
+    auto mode   = callee->decurry()->arg();
+    auto s      = callee->arg();
     auto ls     = Lit::isa(s);
     // TODO cope with wrap around
 
@@ -676,10 +677,10 @@ const Def* normalize_bit2(const Def* type, const Def* c, const Def* arg) {
         case bit2::    t: if (ls) return world.lit(type, *ls-1_u64); break;
         case bit2::  fst: return a;
         case bit2::  snd: return b;
-        case bit2:: nfst: return world.call(bit1::neg,  s, a);
-        case bit2:: nsnd: return world.call(bit1::neg,  s, b);
-        case bit2:: ciff: return world.call(bit2:: iff, s, Defs{b, a});
-        case bit2::nciff: return world.call(bit2::niff, s, Defs{b, a});
+        case bit2:: nfst: return world.call(bit1::neg,  mode, a);
+        case bit2:: nsnd: return world.call(bit1::neg,  mode, b);
+        case bit2:: ciff: return world.call(bit2:: iff, mode, Defs{b, a});
+        case bit2::nciff: return world.call(bit2::niff, mode, Defs{b, a});
         default:         break;
     }
 
@@ -702,7 +703,7 @@ const Def* normalize_bit2(const Def* type, const Def* c, const Def* arg) {
         if (!x && !y) return world.lit(type, 0);
         if ( x &&  y) return ls ? world.lit(type, *ls-1_u64) : nullptr;
         if (!x &&  y) return a;
-        if ( x && !y && id != bit2::xor_) return world.call(bit1::neg, s, a);
+        if ( x && !y && id != bit2::xor_) return world.call(bit1::neg, mode, a);
         return nullptr;
     };
     // clang-format on
@@ -738,7 +739,7 @@ const Def* normalize_idx(const Def* type, const Def* c, const Def* arg) {
     if (auto i = Lit::isa(arg)) {
         if (auto s = Lit::isa(Idx::isa(type))) {
             if (*i < *s) return world.lit_idx(*s, *i);
-            if (auto m = Lit::isa(callee->arg())) return *m ? world.bot(type) : world.lit_idx_mod(*s, *i);
+            if (auto m = Lit::isa(callee->decurry()->arg())) return *m ? world.bot(type) : world.lit_idx_mod(*s, *i);
         }
     }
 
@@ -788,7 +789,7 @@ const Def* normalize_wrap(const Def* type, const Def* c, const Def* arg) {
     auto& world = type->world();
     auto callee = c->as<App>();
     auto [a, b] = arg->projs<2>();
-    auto mode   = callee->arg();
+    auto mode   = callee->decurry()->arg();
     auto s      = Idx::isa(a->type());
     auto ls     = Lit::isa(s);
     auto width  = ls.transform(idx_shift_width);

--- a/src/mim/plug/ll/ll.cpp
+++ b/src/mim/plug/ll/ll.cpp
@@ -614,10 +614,10 @@ std::optional<std::string> Emitter::emit_core(BB& bb, const std::string& name, c
 
         return bb.assign(name, "{} {} {}, {}", op, t, a, b);
     } else if (auto wrap = Axm::isa<core::wrap>(def)) {
-        auto [mode, ab] = wrap->uncurry_args<2>();
-        auto [a, b]     = ab->projs<2>([this](auto def) { return emit(def); });
-        auto t          = convert(wrap->type());
-        auto lmode      = static_cast<core::Mode>(Lit::expect(mode, "a `%core.wrap` mode"));
+        auto [mode, _, ab] = wrap->uncurry_args<3>();
+        auto [a, b]        = ab->projs<2>([this](auto def) { return emit(def); });
+        auto t             = convert(wrap->type());
+        auto lmode         = static_cast<core::Mode>(Lit::expect(mode, "a `%core.wrap` mode"));
 
         switch (wrap.id()) {
             case core::wrap::add: op = "add"; break;
@@ -817,10 +817,10 @@ std::optional<std::string> Emitter::emit_mem(BB& bb, const std::string& name, co
 std::optional<std::string> Emitter::emit_math(BB& bb, const std::string& name, const Def* def) {
     std::string op;
     if (auto arith = Axm::isa<math::arith>(def)) {
-        auto [mode, ab] = arith->uncurry_args<2>();
-        auto [a, b]     = ab->projs<2>([this](auto def) { return emit(def); });
-        auto t          = convert(arith->type());
-        auto lmode      = static_cast<math::Mode>(Lit::expect(mode, "a `%math.arith` mode"));
+        auto [mode, _, ab] = arith->uncurry_args<3>();
+        auto [a, b]        = ab->projs<2>([this](auto def) { return emit(def); });
+        auto t             = convert(arith->type());
+        auto lmode         = static_cast<math::Mode>(Lit::expect(mode, "a `%math.arith` mode"));
 
         switch (arith.id()) {
             case math::arith::add: op = "fadd"; break;
@@ -1040,7 +1040,7 @@ std::optional<std::string> Emitter::emit_vec(BB& bb, const std::string& name, co
             }
         } else if (auto arith_op = Axm::isa<math::arith, 1>(f)) {
             auto lmode = static_cast<math::Mode>(
-                Lit::expect(f->expect<App>("a zipped `%math.arith`")->arg(), "a `%math.arith` mode"));
+                Lit::expect(f->expect<App>("a zipped `%math.arith`")->decurry()->arg(), "a `%math.arith` mode"));
             switch (arith_op.id()) {
                 case math::arith::add: op = "fadd"; break;
                 case math::arith::sub: op = "fsub"; break;

--- a/src/mim/plug/math/math.mim
+++ b/src/mim/plug/math/math.mim
@@ -3,8 +3,9 @@
 /// @see mim::plug::math
 ///
 /// Introduces a type constructor `math.F` for various [IEEE-754](https://en.wikipedia.org/wiki/IEEE_754) floating-point formats and a set of operations to calculate with instances of these types.
-/// All operations with the exception of `math.conv` expect a `Nat` just in front of their actual argument.
+/// All operations with the exception of `math.conv` expect a `Nat` as their very first argument.
 /// Via this [mode](@ref mim::plug::math::Mode) you can fine-tune how strictly floating-point transformations must obey IEEE semantics.
+/// It comes before the implicit `pe` so that currying it - `math.arith.add 0` - still yields a value polymorphic in `pe`.
 ///
 /// [TOC]
 ///
@@ -41,9 +42,9 @@ anx let PXR24   = F pxr24;
 ///
 /// Arithmetic operations.
 axm arith.(add, sub, mul, div, rem):
-    {pe: «2; Nat»} → Nat → «2; F pe» → F pe, normalize_arith;
+    Nat → {pe: «2; Nat»} → «2; F pe» → F pe, normalize_arith;
 
-anx lam minus {pe: «2; Nat»} (m: Nat) (a: F pe): F pe =
+anx lam minus (m: Nat) {pe: «2; Nat»} (a: F pe): F pe =
     arith.sub m (0:(F pe), a);
 ///
 /// ### math.extrema
@@ -71,7 +72,7 @@ anx lam minus {pe: «2; Nat»} (m: Nat) (a: F pe): F pe =
 ///
 axm extrema.(im = fmin,       iM = fmax,
              Im = ieee754min, IM = ieee754max):
-    {pe: «2; Nat»} → Nat → «2; F pe» → F pe, normalize_extrema;
+    Nat → {pe: «2; Nat»} → «2; F pe» → F pe, normalize_extrema;
 ///
 /// ### math.tri
 ///
@@ -104,13 +105,13 @@ axm tri.(ahff =  sin     , ahfF =  cos , ahFf =  tan , ahFF,
          aHff =  sinh = h, aHfF =  cosh, aHFf =  tanh, aHFF,
          Ahff = asin  = a, AhfF = acos , AhFf = atan , AhFF,
          AHff = asinh    , AHfF = acosh, AHFf = atanh, AHFF):
-    {pe: «2; Nat»} → Nat → F pe → F pe, normalize_tri;
+    Nat → {pe: «2; Nat»} → F pe → F pe, normalize_tri;
 ///
 /// ### math.pow
 ///
 /// Power function: \f$x^y\f$
 ///
-axm pow: {pe: «2; Nat»} → Nat → «2; F pe» → F pe, normalize_pow;
+axm pow: Nat → {pe: «2; Nat»} → «2; F pe» → F pe, normalize_pow;
 ///
 /// ### math.rt
 ///
@@ -121,7 +122,7 @@ axm pow: {pe: «2; Nat»} → Nat → «2; F pe» → F pe, normalize_pow;
 /// | `math.rt.sq` | square root | \f$\sqrt{x}\f$     |
 /// | `math.rt.cb` | cube root   | \f$\sqrt[3]{x}\f$  |
 ///
-axm rt.(sq, cb): {pe: «2; Nat»} → Nat → F pe → F pe, normalize_rt;
+axm rt.(sq, cb): Nat → {pe: «2; Nat»} → F pe → F pe, normalize_rt;
 ///
 /// ### math.exp
 ///
@@ -142,7 +143,7 @@ axm rt.(sq, cb): {pe: «2; Nat»} → Nat → F pe → F pe, normalize_rt;
 ///
 axm exp.(lbb = exp, lbB = exp2 = bin, lBb = exp10 = dec, lBB,
          Lbb = log, LbB = log2      , LBb = log10      , LBB):
-    {pe: «2; Nat»} → Nat → F pe → F pe, normalize_exp;
+    Nat → {pe: «2; Nat»} → F pe → F pe, normalize_exp;
 ///
 /// ### math.er
 ///
@@ -153,7 +154,7 @@ axm exp.(lbb = exp, lbB = exp2 = bin, lBb = exp10 = dec, lBB,
 /// | `math.er.f`   | error function               | \f$\frac{2}{\sqrt\pi}\int_0^x e^{-t^2}\,dt\f$                            |
 /// | `math.er.fc`  | complementary error function | \f$\frac{2}{\sqrt\pi}\int_x^\infty e^{-t^2}\,dt = 1 - \textrm{erf}(x)\f$ |
 ///
-axm er.(f, fc): {pe: «2; Nat»} → Nat → F pe → F pe, normalize_er;
+axm er.(f, fc): Nat → {pe: «2; Nat»} → F pe → F pe, normalize_er;
 ///
 /// ### math.gamma
 ///
@@ -164,13 +165,13 @@ axm er.(f, fc): {pe: «2; Nat»} → Nat → F pe → F pe, normalize_er;
 /// | `math.gamma.t`    | gamma function                      | \f$\Gamma(x) = \int_0^\infty t^{x-1} e^{-t}\,dt\f$               |
 /// | `math.gamma.l`    | natural logarithm of gamma function | \f$\ln \mid \int_0^\infty t^{x-1} e^{-t}\,dt \mid\f$ |
 ///
-axm gamma.(t, l): {pe: «2; Nat»} → Nat → F pe → F pe, normalize_gamma;
+axm gamma.(t, l): Nat → {pe: «2; Nat»} → F pe → F pe, normalize_gamma;
 ///
 /// ### math.abs
 ///
 /// [Absolute value](https://en.wikipedia.org/wiki/Absolute_value) of a floating-point number.
 ///
-axm abs: {pe: «2; Nat»} → Nat → F pe → F pe, normalize_abs;
+axm abs: Nat → {pe: «2; Nat»} → F pe → F pe, normalize_abs;
 ///
 /// ### math.round
 ///
@@ -187,7 +188,7 @@ axm abs: {pe: «2; Nat»} → Nat → F pe → F pe, normalize_abs;
 /// | `math.round.r`   | [round to nearest integer](https://en.wikipedia.org/wiki/Rounding#Rounding_to_the_nearest_integer) | \f$round (x)\f$          |
 /// | `math.round.t`   | [round towards zero](https://en.wikipedia.org/wiki/Rounding#Rounding_toward_zero)                  | \f$trunc (x)\f$          |
 ///
-axm round.(f,c,r,t): {pe: «2; Nat»} → Nat → F pe → F pe, normalize_round;
+axm round.(f,c,r,t): Nat → {pe: «2; Nat»} → F pe → F pe, normalize_round;
 ///
 /// ## Other Operations
 ///
@@ -222,13 +223,13 @@ axm cmp.(ugle =   f, uglE =   e, ugLe =   l, ugLE =  le,
          uGle =   g, uGlE =  ge, uGLe =  ne, uGLE =   o,
          Ugle =   u, UglE =  ue, UgLe =  ul, UgLE = ule,
          UGle =  ug, UGlE = uge, UGLe = une, UGLE =   t):
-    {pe: «2; Nat»} → Nat → «2; F pe» → Bool, normalize_cmp;
+    Nat → {pe: «2; Nat»} → «2; F pe» → Bool, normalize_cmp;
 ///
 /// ### math.is_finite
 ///
 /// Returns `tt` if the float is finite and `ff` if not (i.e. if it is ±∞ or NaN).
 ///
-axm is_finite: {pe: «2; Nat»} → Nat → F pe → Bool;
+axm is_finite: Nat → {pe: «2; Nat»} → F pe → Bool;
 ///
 /// ### math.conv
 ///
@@ -245,15 +246,15 @@ pub mod conv {
 /// ### math.slf
 /// [Standard logistic function](https://en.wikipedia.org/wiki/Logistic_function) of a floating-point number (\f$\textrm{slf}(x) = \frac{1}{1+e^{-x}}\f$)
 ///
-anx lam slf {pe: «2; Nat»} (m: Nat) (x: F pe): F pe =
+anx lam slf (m: Nat) {pe: «2; Nat»} (x: F pe): F pe =
     arith.div m ((conv.f2f pe 1.0:(F64)), arith.add m ((conv.f2f pe 1.0:(F64)), exp.exp m (minus m x)));
 ///
 /// ### math.sgn
 /// [Sign function](https://en.wikipedia.org/wiki/Sign_function)
-anx lam sgn {pe: «2; Nat»} (m: Nat) (x: F pe): F pe =
+anx lam sgn (m: Nat) {pe: «2; Nat»} (x: F pe): F pe =
     ((conv.f2f pe (-1.0:(F64))), ((conv.f2f pe 0.0:(F64)), (conv.f2f pe 1.0:(F64)))#(cmp.g m (x,(conv.f2f pe 0.0:(F64)))))#(cmp.ge m (x, (conv.f2f pe 0.0:(F64))));
 ///
 /// ### math.rrt
 /// [Reciprocal](https://en.wikipedia.org/wiki/Multiplicative_inverse) of the [square root](https://en.wikipedia.org/wiki/Square_root) (\f$\textrm{rrt}(x) = \frac{1}{\sqrt{x}}\f$)
-anx lam rrt {pe: «2; Nat»} (m: Nat) (x: F pe): F pe =
+anx lam rrt (m: Nat) {pe: «2; Nat»} (x: F pe): F pe =
     arith.div m (conv.f2f pe 1.0:(F64), rt.sq m x);

--- a/src/mim/plug/math/math.mim
+++ b/src/mim/plug/math/math.mim
@@ -36,6 +36,26 @@ anx let NVTF32  = F nvtf32; // actually 19 bits; aligns to 32 bit
 anx let AMDFP24 = F amdfp24;
 anx let PXR24   = F pxr24;
 ///
+/// ## Mode
+///
+/// ### math.mode
+///
+/// Fine-tunes how strictly a floating-point operation must obey IEEE semantics - see mim::plug::math::Mode.
+///
+pub mod mode {
+    pub anx let none     = 0b0000000; // no optimizations allowed
+    pub anx let nnan     = 0b0000001; // no NaNs
+    pub anx let ninf     = 0b0000010; // no Infs
+    pub anx let nsz      = 0b0000100; // no signed zeros
+    pub anx let arcp     = 0b0001000; // allow reciprocal instead of division
+    pub anx let contract = 0b0010000; // allow contraction, e.g. fused multiply-add
+    pub anx let afn      = 0b0100000; // allow approximate functions
+    pub anx let reassoc  = 0b1000000; // allow reassociation
+    pub anx let finite   = 0b0000011; // nnan | ninf
+    pub anx let unsafe   = 0b1001100; // nsz | arcp | reassoc
+    pub anx let fast     = 0b1111111; // everything above
+}
+///
 /// ## Numerical Operations
 ///
 /// ### math.arith
@@ -258,3 +278,76 @@ anx lam sgn (m: Nat) {pe: «2; Nat»} (x: F pe): F pe =
 /// [Reciprocal](https://en.wikipedia.org/wiki/Multiplicative_inverse) of the [square root](https://en.wikipedia.org/wiki/Square_root) (\f$\textrm{rrt}(x) = \frac{1}{\sqrt{x}}\f$)
 anx lam rrt (m: Nat) {pe: «2; Nat»} (x: F pe): F pe =
     arith.div m (conv.f2f pe 1.0:(F64), rt.sq m x);
+///
+/// ### math.ops
+///
+/// Bindings for the infix operators, which are sugar for an application of the escaped name.
+/// `use` the module whose math.mode matches the accuracy you are willing to trade:
+///
+/// | Module            | Mode               |
+/// |-------------------|--------------------|
+/// | `math.ops.none`   | `math.mode.none`   |
+/// | `math.ops.finite` | `math.mode.finite` |
+/// | `math.ops.unsafe` | `math.mode.unsafe` |
+/// | `math.ops.fast`   | `math.mode.fast`   |
+///
+/// `!=` is math.cmp.une - the exact complement of `==` - and hence `tt` if an operand is a NaN.
+/// All other comparisons are ordered and thus `ff` in that case.
+///
+pub mod ops {
+    pub mod none {
+        pub let `+  = arith.add mode.none;
+        pub let `-  = arith.sub mode.none;
+        pub let `*  = arith.mul mode.none;
+        pub let `/  = arith.div mode.none;
+        pub let `%  = arith.rem mode.none;
+        pub let `== =   cmp.e   mode.none;
+        pub let `!= =   cmp.une mode.none;
+        pub let `<  =   cmp.l   mode.none;
+        pub let `<= =   cmp.le  mode.none;
+        pub let `>  =   cmp.g   mode.none;
+        pub let `>= =   cmp.ge  mode.none;
+    }
+
+    pub mod finite {
+        pub let `+  = arith.add mode.finite;
+        pub let `-  = arith.sub mode.finite;
+        pub let `*  = arith.mul mode.finite;
+        pub let `/  = arith.div mode.finite;
+        pub let `%  = arith.rem mode.finite;
+        pub let `== =   cmp.e   mode.finite;
+        pub let `!= =   cmp.une mode.finite;
+        pub let `<  =   cmp.l   mode.finite;
+        pub let `<= =   cmp.le  mode.finite;
+        pub let `>  =   cmp.g   mode.finite;
+        pub let `>= =   cmp.ge  mode.finite;
+    }
+
+    pub mod unsafe {
+        pub let `+  = arith.add mode.unsafe;
+        pub let `-  = arith.sub mode.unsafe;
+        pub let `*  = arith.mul mode.unsafe;
+        pub let `/  = arith.div mode.unsafe;
+        pub let `%  = arith.rem mode.unsafe;
+        pub let `== =   cmp.e   mode.unsafe;
+        pub let `!= =   cmp.une mode.unsafe;
+        pub let `<  =   cmp.l   mode.unsafe;
+        pub let `<= =   cmp.le  mode.unsafe;
+        pub let `>  =   cmp.g   mode.unsafe;
+        pub let `>= =   cmp.ge  mode.unsafe;
+    }
+
+    pub mod fast {
+        pub let `+  = arith.add mode.fast;
+        pub let `-  = arith.sub mode.fast;
+        pub let `*  = arith.mul mode.fast;
+        pub let `/  = arith.div mode.fast;
+        pub let `%  = arith.rem mode.fast;
+        pub let `== =   cmp.e   mode.fast;
+        pub let `!= =   cmp.une mode.fast;
+        pub let `<  =   cmp.l   mode.fast;
+        pub let `<= =   cmp.le  mode.fast;
+        pub let `>  =   cmp.g   mode.fast;
+        pub let `>= =   cmp.ge  mode.fast;
+    }
+}

--- a/src/mim/plug/math/math.mim
+++ b/src/mim/plug/math/math.mim
@@ -279,7 +279,7 @@ anx lam sgn (m: Nat) {pe: «2; Nat»} (x: F pe): F pe =
 anx lam rrt (m: Nat) {pe: «2; Nat»} (x: F pe): F pe =
     arith.div m (conv.f2f pe 1.0:(F64), rt.sq m x);
 ///
-/// ### math.ops
+/// ## ops
 ///
 /// Bindings for the infix operators, which are sugar for an application of the escaped name.
 /// `use` the module whose math.mode matches the accuracy you are willing to trade:

--- a/src/mim/plug/math/normalizers.cpp
+++ b/src/mim/plug/math/normalizers.cpp
@@ -290,7 +290,7 @@ const Def* reassociate(Id id, World& world, [[maybe_unused]] const App* ab, cons
     // build mode for all new ops by using the least upper bound of all involved apps
     auto mode       = std::to_underlying(Mode::bot);
     auto check_mode = [&](const App* app) {
-        auto app_m = Lit::isa(app->arg(0));
+        auto app_m = Lit::isa(app->decurry()->arg());
         if (!app_m || !fe::has_flag(static_cast<Mode>(*app_m), Mode::reassoc)) return false;
         mode &= *app_m; // least upper bound
         return true;
@@ -347,7 +347,7 @@ const Def* normalize_arith(const Def* type, const Def* c, const Def* arg) {
     auto& world = type->world();
     auto callee = c->as<App>();
     auto [a, b] = arg->projs<2>();
-    auto mode   = callee->arg();
+    auto mode   = callee->decurry()->arg();
     auto lm     = Lit::isa(mode);
     auto w      = isa_f(a->type());
 
@@ -416,7 +416,7 @@ const Def* normalize_extrema(const Def* type, const Def* c, const Def* arg) {
     auto& world = type->world();
     auto callee = c->as<App>();
     auto [a, b] = arg->projs<2>();
-    auto m      = callee->arg();
+    auto m      = callee->decurry()->arg();
     auto lm     = Lit::isa(m);
     // TODO commute
 

--- a/src/mim/plug/tensor/tensor.mim
+++ b/src/mim/plug/tensor/tensor.mim
@@ -284,13 +284,13 @@ anx lam interchange (t: Tileable, perm: «core.nat.add (t#Ro, t#Rr); Nat»): Til
                          refly.check (core.icmp.e @2 (core.ncmp.l (jj, t#Ro), core.ncmp.l (perm#j, t#Ro)),
                                        perm#j,
                                        "interchange: permutation must not mix parallel and reduction dims")›;
-    let sr_n   = ‹i: r; t#Sr#(core.idx r 0 (perm_ok#i))›;
+    let sr_n   = ‹i: r; t#Sr#(core.idx 0 r (perm_ok#i))›;
     let vdim_n = match vec.first core.ncmp.e (perm_ok, t#vdim) with
                      | j: Idx r => core.bitcast Nat j
                      | _: []    => t#vdim;
     // The parallel dims permute among themselves (checked above), so the new dim j writes the
     // output axis its old dim perm#j wrote.
-    let oax_n = ‹j: t#Ro; t#oax#(core.idx (t#Ro) 0 (perm_ok#(core.idx r 0 (core.bitcast Nat j))))›;
+    let oax_n = ‹j: t#Ro; t#oax#(core.idx 0 (t#Ro) (perm_ok#(core.idx 0 r (core.bitcast Nat j))))›;
     // iota: old dim i is found at the new position j with perm#j = i.
     lam iota_p (o: «r; affine.Index»): «r; affine.Index» =
         ‹i: r; o#(option.unwrap_unsafe (vec.first core.ncmp.e (perm_ok, core.bitcast Nat i)))›;
@@ -319,27 +319,27 @@ lam shift_ax (a x: Nat): Nat = core.select (core.ncmp.l (x, a), x, core.nat.add 
 /// re-associate core.nat.add symbolically).
 lam split_bounds (m n: Nat, v: «n; Nat», d ts nt: Nat): «m; Nat» =
     ‹i: m; let ii = core.bitcast Nat i;
-           core.select (core.ncmp.l (ii, d), v#(core.idx n 0 ii),
+           core.select (core.ncmp.l (ii, d), v#(core.idx 0 n ii),
            core.select (core.ncmp.e (ii, d), nt,
            core.select (core.ncmp.e (ii, core.nat.add (d, 1)), ts,
-           v#(core.idx n 0 (core.nat.sub (ii, 1))))))›;
+           v#(core.idx 0 n (core.nat.sub (ii, 1))))))›;
 
 /// Recombine a split loop vector (m = n+1): old#d = new#d · ts + new#(d+1).
 lam split_iota (m n d ts: Nat) (o: «m; affine.Index»): «n; affine.Index» =
     ‹j: n; let jj = core.bitcast Nat j;
-           core.select (core.ncmp.l (jj, d), o#(core.idx m 0 jj),
+           core.select (core.ncmp.l (jj, d), o#(core.idx 0 m jj),
            core.select (core.ncmp.e (jj, d),
-                         affine.op.add (affine.semiop.mul (o#(core.idx m 0 d), ts),
-                                         o#(core.idx m 0 (core.nat.add (d, 1)))),
-           o#(core.idx m 0 (core.nat.add (jj, 1)))))›;
+                         affine.op.add (affine.semiop.mul (o#(core.idx 0 m d), ts),
+                                         o#(core.idx 0 m (core.nat.add (d, 1)))),
+           o#(core.idx 0 m (core.nat.add (jj, 1)))))›;
 
 /// Split an output coordinate vector (m = n+1): new#a = old#a ⌊/⌋ ts, new#(a+1) = old#a mod ts.
 lam split_omega (m n a ts: Nat) (oc: «n; affine.Index»): «m; affine.Index» =
     ‹j: m; let jj = core.bitcast Nat j;
-           core.select (core.ncmp.l (jj, a), oc#(core.idx n 0 jj),
-           core.select (core.ncmp.e (jj, a), affine.semiop.floordiv (oc#(core.idx n 0 a), ts),
-           core.select (core.ncmp.e (jj, core.nat.add (a, 1)), affine.semiop.rem (oc#(core.idx n 0 a), ts),
-           oc#(core.idx n 0 (core.nat.sub (jj, 1))))))›;
+           core.select (core.ncmp.l (jj, a), oc#(core.idx 0 n jj),
+           core.select (core.ncmp.e (jj, a), affine.semiop.floordiv (oc#(core.idx 0 n a), ts),
+           core.select (core.ncmp.e (jj, core.nat.add (a, 1)), affine.semiop.rem (oc#(core.idx 0 n a), ts),
+           oc#(core.idx 0 n (core.nat.sub (jj, 1))))))›;
 
 /// Checks that `ts` exactly divides the extent `sd` (discharges symbolically for factored extents).
 lam check_div (sd ts: Nat): Nat =
@@ -352,7 +352,7 @@ lam check_div (sd ts: Nat): Nat =
 anx lam strip_mine_red (t: Tileable, d ts: Nat): Tileable =
     let r   = core.nat.add (t#Ro, t#Rr);
     let r_n = core.nat.add (t#Ro, core.nat.add (t#Rr, 1));
-    let nt  = core.nat.div (check_div (t#Sr#(core.idx r 0 d), ts), ts);
+    let nt  = core.nat.div (check_div (t#Sr#(core.idx 0 r d), ts), ts);
     let vdim_n   = core.select (core.ncmp.l (t#vdim, t#Ro), t#vdim, r_n);
     let unroll_n = core.select (core.ncmp.l (d, core.nat.sub (r, t#unroll)),
                                  t#unroll, core.nat.add (t#unroll, 1));
@@ -374,19 +374,19 @@ anx lam strip_mine_par (t: Tileable, d ts: Nat): Tileable =
     let r    = core.nat.add (t#Ro, t#Rr);
     let ro_n = core.nat.add (t#Ro, 1);
     let r_n  = core.nat.add (core.nat.add (t#Ro, 1), t#Rr);
-    let a    = t#oax#(core.idx (t#Ro) 0 d);
-    let sd   = refly.check (core.ncmp.e (t#So#(core.idx (t#Ro) 0 a), t#Sr#(core.idx r 0 d)),
-                             t#Sr#(core.idx r 0 d),
+    let a    = t#oax#(core.idx 0 (t#Ro) d);
+    let sd   = refly.check (core.ncmp.e (t#So#(core.idx 0 (t#Ro) a), t#Sr#(core.idx 0 r d)),
+                             t#Sr#(core.idx 0 r d),
                              "strip_mine_par: output extent (at oax#d) must match domain extent");
     let nt   = core.nat.div (check_div (sd, ts), ts);
     // The split dim writes the split axis pair; all other dims write their old axis, renumbered
     // around the insertion at `a`. The unit-stride half is the inner one: a vdim at `d` moves to
     // `d + 1`.
     let oax_n = ‹j: ro_n; let jj = core.bitcast Nat j;
-                          core.select (core.ncmp.l (jj, d), shift_ax (a, t#oax#(core.idx (t#Ro) 0 jj)),
+                          core.select (core.ncmp.l (jj, d), shift_ax (a, t#oax#(core.idx 0 (t#Ro) jj)),
                           core.select (core.ncmp.e (jj, d), a,
                           core.select (core.ncmp.e (jj, core.nat.add (d, 1)), core.nat.add (a, 1),
-                          shift_ax (a, t#oax#(core.idx (t#Ro) 0 (core.nat.sub (jj, 1)))))))›;
+                          shift_ax (a, t#oax#(core.idx 0 (t#Ro) (core.nat.sub (jj, 1)))))))›;
     let vdim_n = core.select (core.ncmp.l (t#vdim, t#Ro),
                                core.select (core.ncmp.l (t#vdim, d), t#vdim, core.nat.add (t#vdim, 1)),
                                r_n);
@@ -422,7 +422,7 @@ lam sched_id (t: Tileable): Tileable = t;
 lam unroll_budget (t: Tileable, budget: Nat): Nat =
     let r = core.nat.add (t#Ro, t#Rr);
     lam step (d: Nat, st: «3; Nat»): «3; Nat» =
-        let taps  = core.nat.mul (st#1_3, t#Sr#(core.idx r 0 d));
+        let taps  = core.nat.mul (st#1_3, t#Sr#(core.idx 0 r d));
         let ok    = if_static (taps, (0, 1)#(core.ncmp.le (taps, budget)), 0);
         let alive = core.nat.mul (st#2_3, ok);
         (core.nat.add (st#0_3, alive),
@@ -452,7 +452,7 @@ lam conv_schedule (stride dilation: «2; Nat») (t: Tileable): Tileable =
     let s_red = core.select (core.ncmp.e (u, 0),
                               core.nat.add ((0, 1)#(core.ncmp.e (dilation#1_2, 1)), 1),
                               core.select (core.ncmp.l (u, t#Rr), 0, s_ow));
-    let ow    = t#Sr#(core.idx (core.nat.add (t#Ro, t#Rr)) 0 3);
+    let ow    = t#Sr#(core.idx 0 (core.nat.add (t#Ro, t#Rr)) 3);
     let vec   = if_static (core.nat.mul (core.nat.mul (stride#1_2, dilation#1_2), ow),
                                    core.ncmp.l (s_red, s_ow), ff);
     // Rows too short for the vectorizer (ow < 16) are processed in BLOCKS: strip-mine oh by the
@@ -461,7 +461,7 @@ lam conv_schedule (stride dilation: «2; Nat») (t: Tileable): Tileable =
     // whole row block, sharing the hoisted window weights). Otherwise the split is the neutral
     // ts = 1 (its size-1 axis folds away), so one code path serves every case and no divisibility
     // check fires on an untaken choice.
-    let oh    = t#Sr#(core.idx (core.nat.add (t#Ro, t#Rr)) 0 2);
+    let oh    = t#Sr#(core.idx 0 (core.nat.add (t#Ro, t#Rr)) 2);
     lam divides (d: Nat): Bool = core.ncmp.e (core.nat.mul (core.nat.div (oh, d), d), oh);
     let bs    = ((1, 2)#(divides 2), 4)#(divides 4);
     let block = if_static (core.nat.mul (oh, ow),
@@ -483,7 +483,7 @@ lam conv_schedule (stride dilation: «2; Nat») (t: Tileable): Tileable =
 lam dot_schedule (r_out: Nat) (t: Tileable): Tileable =
     let r   = core.nat.add (t#Ro, t#Rr);
     let d   = core.nat.sub (r, 1);
-    let K   = t#Sr#(core.idx r 0 d);
+    let K   = t#Sr#(core.idx 0 r d);
     let ts0 = (1, 4)#(core.ncmp.e (core.nat.mul (core.nat.div (K, 4), 4), K));
     let ts  = if_static (ts0, ts0, 1);
     unroll_trailing (strip_mine_red (vectorize (t, core.nat.sub (r_out, 1)), d, ts), 1);
@@ -508,11 +508,11 @@ lam dot_schedule_kvec (r_out: Nat) (t: Tileable): Tileable =
     lam blk_by (k b: Nat): Bool = core.bit2.and_ 2 (core.ncmp.e (core.nat.mul (core.nat.div (k, b), b), k),
                                                      core.ncmp.l (b, k));
     let d   = core.nat.sub (r_out, 1);
-    let n   = t#So#(core.idx (t#Ro) 0 d);
+    let n   = t#So#(core.idx 0 (t#Ro) d);
     let bs  = if_static (n, ((1, 2)#(blk_by (n, 2)), 4)#(blk_by (n, 4)), 1);
     let t2  = strip_mine_par (t, d, bs);
     let d2  = core.nat.sub (r_out, 2);
-    let m   = t#So#(core.idx (t#Ro) 0 d2);
+    let m   = t#So#(core.idx 0 (t#Ro) d2);
     let ms  = (1, if_static (m, (1, 2)#(blk_by (m, 2)), 1))#(core.ncmp.le (2, r_out));
     let t3  = strip_mine_par (t2, d2, ms);
     // Dims now (…, m/ms, ms, n/bs, bs | red): swap ms ↔ n/bs so both jam dims are the trailing
@@ -538,7 +538,7 @@ lam pool_schedule (stride dilation: «2; Nat») (t: Tileable): Tileable =
     let s_red = core.select (core.ncmp.e (u, 0),
                               (0, 1)#(core.ncmp.e (dilation#1_2, 1)),
                               core.select (core.ncmp.l (u, t#Rr), 0, s_ow));
-    let ow    = t#Sr#(core.idx (core.nat.add (t#Ro, t#Rr)) 0 3);
+    let ow    = t#Sr#(core.idx 0 (core.nat.add (t#Ro, t#Rr)) 3);
     let vec   = if_static (core.nat.mul (core.nat.mul (stride#1_2, dilation#1_2), ow),
                                    core.ncmp.l (s_red, s_ow), ff);
     unroll_trailing (vectorize_if (t, vec, 3), u);
@@ -660,7 +660,7 @@ lam concat_acc {r: Nat} (ax: Idx r) (acc: Nat, row: «r; Nat»): Nat = core.nat.
 // `(ax, Sis) ↦ s_out`: sums the inputs' extents along `ax`, keeps the shared extents on every other axis.
 lam concat_shape {nis r: Nat} (ax: Idx r, Sis: «nis; «r; Nat»»): «r; Nat» =
     let sum_ax = vec.fold.l (concat_acc ax) (0, Sis);
-    let row_0  = Sis#(core.idx nis 0 0);
+    let row_0  = Sis#(core.idx 0 nis 0);
     ‹d: r; core.select (core.icmp.e (d, ax), sum_ax, row_0#d)›;
 
 axm concat: {T: *, nis r: Nat}

--- a/src/mim/plug/tuple/tuple.mim
+++ b/src/mim/plug/tuple/tuple.mim
@@ -58,8 +58,8 @@ anx lam prepend  {m: Nat}
 anx lam head {n: Nat}
     {Ts: «n; *»}
     (values: «i: n; Ts#i»)
-  : [Ts#(core.idx n core.mode.US 0)]
-  = values#(core.idx n core.mode.US 0);
+  : [Ts#(core.idx core.mode.US n 0)]
+  = values#(core.idx core.mode.US n 0);
 
 anx lam tail {n: Nat}
     {Ts: «n; *»}

--- a/src/mim/plug/vec/vec.mim
+++ b/src/mim/plug/vec/vec.mim
@@ -49,10 +49,10 @@ axm scan.(for_all, exists): {E: *} → {n: Nat} → [p: E → Bool] → «n; E»
 ///
 /// Yields the index of the first/last occurrence of the given element, or option.none if it does not occur.
 ///
-lam f_first    {E: *} {n: Nat} (eq: [E, E] → Bool) (x: E) ((b: Bool, i: Idx n), y: E): [Bool, Idx n] = (((ff, core.wrap.add 0 (i, core.idx n 0 1)), (tt, i))#(eq (x, y)), (b, i))#b;
+lam f_first    {E: *} {n: Nat} (eq: [E, E] → Bool) (x: E) ((b: Bool, i: Idx n), y: E): [Bool, Idx n] = (((ff, core.wrap.add 0 (i, core.idx 0 n 1)), (tt, i))#(eq (x, y)), (b, i))#b;
 lam f_last     {E: *} {n: Nat} (eq: [E, E] → Bool) (x: E) (y: E, (b: Bool, i: Idx n)): [Bool, Idx n] = f_first eq x ((b, i), y);
-anx lam first {E: *} {n: Nat} (eq: [E, E] → Bool) (v: «n; E», x: E): option.Opt (Idx n) = option.some_if (fold.l (f_first eq x) ((ff, core.idx n 0 0), v));
-anx lam last  {E: *} {n: Nat} (eq: [E, E] → Bool) (v: «n; E», x: E): option.Opt (Idx n) = option.some_if (fold.r (f_last  eq x) (v, (ff, core.idx n 0 0)));
+anx lam first {E: *} {n: Nat} (eq: [E, E] → Bool) (v: «n; E», x: E): option.Opt (Idx n) = option.some_if (fold.l (f_first eq x) ((ff, core.idx 0 n 0), v));
+anx lam last  {E: *} {n: Nat} (eq: [E, E] → Bool) (v: «n; E», x: E): option.Opt (Idx n) = option.some_if (fold.r (f_last  eq x) (v, (ff, core.idx 0 n 0)));
 ///
 /// ### vec.len
 ///


### PR DESCRIPTION
provide standard operators for `Nat`, `Idx s` and `math.F pe` in different variants and flavors and port lit tests to use more concise operators.